### PR TITLE
Fix: add units to font-size declarations in bundled CSS

### DIFF
--- a/src/assets/theme.css
+++ b/src/assets/theme.css
@@ -3,7 +3,7 @@
 :root {
   background-color: #fafafa;
   color: #0a0a0a;
-  font-size: 15;
+  font-size: 15px;
   font-family: 'Noto Sans';
   font-weight: 200;
 }

--- a/src/assets/widgets.css
+++ b/src/assets/widgets.css
@@ -130,7 +130,7 @@ peak-meter .ticks__tick {
 peak-meter .ticks__label {
   position-type: absolute;
   top: 4px; /* In pixels in an attempt to get this to better align to the grid */
-  font-size: 11; /* 14.667px */
+  font-size: 11pt; /* 14.667px */
   left: 1s;
   right: 1s;
 }


### PR DESCRIPTION
## Summary

Vizia commit [`42c89df2`](https://github.com/vizia/vizia/commit/42c89df2ef50dc6604ea4017fbd8cf8e8c026267) (`Use length for font size`, 2025-05-02) changed `FontSize` from `pub f32` to `pub Length`, making unitless `font-size` values invalid. That commit updated vizia-core's own bundled themes (`dark_theme.css`, `default_layout.css`, `light_theme.css`, `markdown.css`) to use `px`, but vizia-plug's bundled stylesheets weren't updated in the same sweep.

Since then, two rules in vizia-plug's CSS have been silently dropped and log `[WARN] Unparsed: font-size` from `vizia_core::style::mod.rs:1537` whenever the editor is created — pluginval reports them on every editor open.

## Rules affected

- `src/assets/theme.css:6` — `:root { font-size: 15; }`
- `src/assets/widgets.css:133` — `peak-meter .ticks__label { font-size: 11; /* 14.667px */ }`

## Fix

Two separate unit choices, for two different reasons:

### `theme.css` — `15` → `15px`

No comment documents an intended physical size for this `:root` rule. I followed the same pattern `42c89df2` already applied to vizia-core's own themes — unitless values were converted to `px`, not `pt`. Examples from that commit:

```diff
 menubutton .shortcut {
     color: #c4c4c4;
-    font-size: 12;
+    font-size: 12px;
 }
```

### `widgets.css` — `11` → `11pt`

This one had an explicit comment: `/* 14.667px */`. The ratio `14.667 / 11 ≈ 1.333…` is exactly `PX_PER_PT = PX_PER_IN / 72 = 96 / 72 = 4/3`, which is the constant vizia itself defines in `crates/vizia_style/src/values/length/value.rs:116`:

```rust
pub const PX_PER_PT: f32 = Self::PX_PER_IN / 72.0;
```

So `11pt` parses to `LengthValue::Pt(11.0)` and `.to_px()` returns `11.0 * (96/72) = 14.6667` — the exact number in the comment. Changing this line to `11px` instead of `11pt` would render the peak-meter tick labels ~25 % smaller than the author's documented intent. Using `pt` restores the declared target.

## Verification

Built a downstream nih-plug plugin against this branch and ran pluginval at max strictness:

```
pluginval --strictness-level 10 --validate my_plugin.vst3
```

Both `[WARN] Unparsed: font-size` messages clear; validation reports `SUCCESS` as before.

## Test plan

- [x] `cargo build` on vizia-plug itself — clean
- [x] Downstream plugin build against this branch — clean
- [x] pluginval at `--strictness-level 10` — `SUCCESS`, no `Unparsed: font-size` warnings