### PR TITLE
Port ParamWidgetBase to signal-based bindings (vizia#619 rebase spike)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vizia_plug"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["George Atkinson <geom3trik@vizia.dev>"]
 license = "MIT"
 description = "An adapter to use VIZIA GUIs with NIH-plug"
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git" }
-vizia = { git = "https://github.com/vizia/vizia", rev = "ea8e7144f00877fd5978ff2eacdce7432b1ddd90", default-features = false, features = ["baseview", "clipboard", "x11"] }
+vizia = { git = "https://github.com/vizia/vizia", rev = "b2f68a02094c2ba9e4f52553295aa350043fe3c1", default-features = false, features = ["baseview", "clipboard", "x11"] }
 # vizia = { path = "../vizia", default_features = false, features = ["baseview", "clipboard", "x11"] }
 
 crossbeam = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,23 @@ nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git" }
 vizia = { git = "https://github.com/vizia/vizia", rev = "b2f68a02094c2ba9e4f52553295aa350043fe3c1", default-features = false, features = ["baseview", "clipboard", "x11"] }
 # vizia = { path = "../vizia", default_features = false, features = ["baseview", "clipboard", "x11"] }
 
+# Direct dependency on `vizia_reactive` so the editor can call
+# `Runtime::drain_pending_work()` as a belt-and-suspenders against
+# `vizia_baseview`'s missing sync-runtime integration. Same rev as the `vizia`
+# umbrella above — resolves to the same crate in the dep graph.
+#
+# TODO: drop this dep once vizia re-exports `Runtime` from `vizia::prelude`
+# AND `vizia_baseview`'s `on_frame_update` calls `Runtime::drain_pending_work()`
+# itself (matching what `vizia_winit` already does). Tracked in the companion
+# vizia PR — see CHANGELOG / PR description for the link.
+vizia_reactive = { git = "https://github.com/vizia/vizia", rev = "b2f68a02094c2ba9e4f52553295aa350043fe3c1", default-features = false }
+
 crossbeam = "0.8"
+# Used by `ParamRegistry` for its signal map — flushing happens from the host /
+# audio thread, and `parking_lot::Mutex` avoids the priority-inversion and
+# poisoning overhead of `std::sync::Mutex` if the UI thread happens to hold the
+# lock during widget construction when a parameter change arrives.
+parking_lot = "0.12"
 # To make the state persistable
 serde = { version = "1.0", features = ["derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git" }
-vizia = { git = "https://github.com/vizia/vizia", rev = "b2f68a02094c2ba9e4f52553295aa350043fe3c1", default-features = false, features = ["baseview", "clipboard", "x11"] }
+vizia = { git = "https://github.com/vizia/vizia", rev = "12ff2584", default-features = false, features = ["baseview", "clipboard", "x11"] }
 # vizia = { path = "../vizia", default_features = false, features = ["baseview", "clipboard", "x11"] }
 
 # Direct dependency on `vizia_reactive` so the editor can call
@@ -26,7 +26,7 @@ vizia = { git = "https://github.com/vizia/vizia", rev = "b2f68a02094c2ba9e4f5255
 # AND `vizia_baseview`'s `on_frame_update` calls `Runtime::drain_pending_work()`
 # itself (matching what `vizia_winit` already does). Tracked in the companion
 # vizia PR — see CHANGELOG / PR description for the link.
-vizia_reactive = { git = "https://github.com/vizia/vizia", rev = "b2f68a02094c2ba9e4f52553295aa350043fe3c1", default-features = false }
+vizia_reactive = { git = "https://github.com/vizia/vizia", rev = "12ff2584", default-features = false }
 
 crossbeam = "0.8"
 # Used by `ParamRegistry` for its signal map — flushing happens from the host /

--- a/examples/gain_gui/src/editor.rs
+++ b/examples/gain_gui/src/editor.rs
@@ -1,25 +1,21 @@
 use atomic_float::AtomicF32;
 use nih_plug::prelude::{util, Editor};
-use vizia_plug::vizia::prelude::*;
-use vizia_plug::widgets::*;
-use vizia_plug::{create_vizia_editor, ViziaState, ViziaTheming};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
+use vizia_plug::vizia::prelude::*;
+use vizia_plug::widgets::*;
+use vizia_plug::{create_vizia_editor, ViziaState, ViziaTheming};
 
 use crate::GainParams;
 
 pub const NOTO_SANS: &str = "Noto Sans";
 
-#[derive(Lens)]
-struct Data {
-    params: Arc<GainParams>,
-    peak_meter: Arc<AtomicF32>,
-}
+/// Interval at which the UI polls the peak-meter atomic that the audio thread writes into.
+/// 50 Hz is smooth enough for a meter and cheap.
+const PEAK_METER_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
-impl Model for Data {}
-
-// Makes sense to also define this here, makes it a bit easier to keep track of
+// Makes sense to also define this here — easier to keep track of.
 pub(crate) fn default_state() -> Arc<ViziaState> {
     ViziaState::new(|| (200, 150))
 }
@@ -30,14 +26,20 @@ pub(crate) fn create(
     editor_state: Arc<ViziaState>,
 ) -> Option<Box<dyn Editor>> {
     create_vizia_editor(editor_state, ViziaTheming::Custom, move |cx, _| {
-        // assets::register_noto_sans_light(cx);
-        // assets::register_noto_sans_thin(cx);
-
-        Data {
-            params: params.clone(),
-            peak_meter: peak_meter.clone(),
-        }
-        .build(cx);
+        // Bridge from the audio thread's `AtomicF32` peak-meter into a `SyncSignal<f32>` the
+        // UI can bind to. The audio thread writes the atomic; we poll it on a short vizia
+        // `Timer` and push the converted dBFS value into the signal. The `PeakMeter` widget
+        // then uses the signal's `SignalGet` implementation to drive its bar and hold-peak
+        // display.
+        let level_dbfs: SyncSignal<f32> = SyncSignal::new(util::MINUS_INFINITY_DB);
+        let poll_target = peak_meter.clone();
+        let timer = cx.add_timer(PEAK_METER_POLL_INTERVAL, None, move |_cx, reason| {
+            if matches!(reason, TimerAction::Tick(_)) {
+                let raw = poll_target.load(Ordering::Relaxed);
+                level_dbfs.set_if_changed(util::gain_to_db(raw));
+            }
+        });
+        cx.start_timer(timer);
 
         VStack::new(cx, |cx| {
             Label::new(cx, "Gain GUI")
@@ -48,16 +50,10 @@ pub(crate) fn create(
                 .alignment(Alignment::BottomCenter);
 
             Label::new(cx, "Gain");
-            ParamSlider::new(cx, Data::params, |params| &params.gain);
+            ParamSlider::new(cx, &params.gain);
 
-            PeakMeter::new(
-                cx,
-                Data::peak_meter
-                    .map(|peak_meter| util::gain_to_db(peak_meter.load(Ordering::Relaxed))),
-                Some(Duration::from_millis(600)),
-            );
+            PeakMeter::new(cx, level_dbfs, Some(Duration::from_millis(600)));
         })
         .alignment(Alignment::TopCenter);
-
     })
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -14,8 +14,6 @@ use crate::widgets::param_registry::ParamRegistry;
 use crate::widgets::RawParamEvent;
 use crate::{widgets, ViziaState, ViziaTheming};
 
-pub const NOTO_SANS: &str = "Noto Sans";
-
 /// An [`Editor`] implementation that calls a vizia draw loop.
 pub(crate) struct ViziaEditor {
     pub(crate) vizia_state: Arc<ViziaState>,
@@ -60,7 +58,10 @@ impl Editor for ViziaEditor {
         let mut application = Application::new(move |cx| {
             // Set some default styles to match the iced integration
             //if theming >= ViziaTheming::Custom {
-                cx.set_default_font(&[NOTO_SANS]);
+                // NOTE: `Context::set_default_font` was removed upstream as a deprecated API
+                // (vizia commit ff943a0b, "Context: remove deprecated APIs and clarify docs").
+                // The default font is now controlled through stylesheets — `theme.css` below
+                // can set `* { font-family: ...; }` if a specific font is required.
                 if let Err(err) = cx.add_stylesheet(include_style!("src/assets/theme.css")) {
                     nih_error!("Failed to load stylesheet: {err:?}");
                     panic!();

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -8,6 +8,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use vizia::prelude::*;
 
+use vizia_reactive::Runtime;
+
+use crate::widgets::param_registry::ParamRegistry;
 use crate::widgets::RawParamEvent;
 use crate::{widgets, ViziaState, ViziaTheming};
 
@@ -31,6 +34,12 @@ pub(crate) struct ViziaEditor {
     /// to compute a property in an event handler. Like when positioning an element based on the
     /// display value's width.
     pub(crate) emit_parameters_changed_event: Arc<AtomicBool>,
+
+    /// Shared registry of `SyncSignal<f32>`s tracking each parameter's live value. Widgets
+    /// subscribe via `cx.data::<ParamRegistry>()`; the editor calls `flush_all()` from the
+    /// `parameter_value_changed` / `parameter_values_changed` hooks so the reactive graph picks
+    /// up value changes that nih-plug reports.
+    pub(crate) param_registry: ParamRegistry,
 }
 
 impl Editor for ViziaEditor {
@@ -42,6 +51,7 @@ impl Editor for ViziaEditor {
         let app = self.app.clone();
         let vizia_state = self.vizia_state.clone();
         let theming = self.theming;
+        let param_registry = self.param_registry.clone();
 
         let (unscaled_width, unscaled_height) = vizia_state.inner_logical_size();
         let system_scaling_factor = self.scaling_factor.load();
@@ -60,6 +70,11 @@ impl Editor for ViziaEditor {
                 // include the style sheet for our custom widgets at context creation
                 widgets::register_theme(cx);
             //}
+
+            // Install the parameter signal registry so widgets can find it via
+            // `cx.data::<ParamRegistry>()`. `ParamRegistry` is a cheap handle (Arc internally),
+            // so the editor keeps a clone for flushing on parameter changes.
+            param_registry.clone().build(cx);
 
             // Any widget can change the parameters by emitting `ParamEvent` events. This model will
             // handle them automatically.
@@ -89,21 +104,37 @@ impl Editor for ViziaEditor {
                 .unwrap_or(WindowScalePolicy::SystemScaleFactor),
         )
         .inner_size((unscaled_width, unscaled_height))
-        .user_scale_factor(user_scale_factor);
-        // .on_idle({
-        //     let emit_parameters_changed_event = self.emit_parameters_changed_event.clone();
-        //     move |cx| {
-        //         if emit_parameters_changed_event
-        //             .compare_exchange(true, false, Ordering::AcqRel, Ordering::Relaxed)
-        //             .is_ok()
-        //         {
-        //             cx.emit_custom(
-        //                 Event::new(RawParamEvent::ParametersChanged)
-        //                     .propagate(Propagation::Subtree),
-        //             );
-        //         }
-        //     }
-        // });
+        .user_scale_factor(user_scale_factor)
+        .on_idle({
+            let emit_parameters_changed_event = self.emit_parameters_changed_event.clone();
+            move |cx| {
+                // Drain effects queued in `SYNC_RUNTIME` by off-UI-thread signal writes (our
+                // `ParamRegistry::flush_all()` runs on nih-plug's parameter-change callback,
+                // which is typically the host / audio thread). This ensures `Binding::new`
+                // subscribers get their rebuild-on-change notifications processed.
+                //
+                // Belt-and-suspenders: `vizia_baseview` should ideally call
+                // `Runtime::drain_pending_work()` from its own `on_frame_update` (matching
+                // what `vizia_winit` already does), in which case this call here becomes a
+                // redundant no-op. Until that lands upstream, this guarantees that
+                // vizia-plug-backed plugins see reactive updates with at most one event-loop
+                // tick of latency.
+                //
+                // TODO: remove once `vizia_baseview` integrates the sync runtime itself.
+                // Tracked by the companion vizia PR — see the vizia-plug PR description.
+                Runtime::drain_pending_work();
+
+                if emit_parameters_changed_event
+                    .compare_exchange(true, false, Ordering::AcqRel, Ordering::Relaxed)
+                    .is_ok()
+                {
+                    cx.emit_custom(
+                        Event::new(RawParamEvent::ParametersChanged)
+                            .propagate(Propagation::Subtree),
+                    );
+                }
+            }
+        });
 
         // This way the plugin can decide to use none of the built in theming
         if theming == ViziaTheming::None {
@@ -139,19 +170,22 @@ impl Editor for ViziaEditor {
     }
 
     fn param_value_changed(&self, _id: &str, _normalized_value: f32) {
-        // This will cause a future idle callback to send a parameters changed event.
-        // NOTE: We could add an event containing the parameter's ID and the normalized value, but
-        //       these events aren't really necessary for Vizia.
+        // Push the new value into the registry's signals — observers bound via `Binding::new`
+        // wake up and rebuild. Also flag a `ParametersChanged` idle event for any widgets that
+        // still rely on the older (pre-signal) notification path.
+        self.param_registry.flush_all();
         self.emit_parameters_changed_event
             .store(true, Ordering::Relaxed);
     }
 
     fn param_modulation_changed(&self, _id: &str, _modulation_offset: f32) {
+        self.param_registry.flush_all();
         self.emit_parameters_changed_event
             .store(true, Ordering::Relaxed);
     }
 
     fn param_values_changed(&self) {
+        self.param_registry.flush_all();
         self.emit_parameters_changed_event
             .store(true, Ordering::Relaxed);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ pub use vizia;
 mod editor;
 pub mod widgets;
 
+use widgets::param_registry::ParamRegistry;
+
 /// Create an [`Editor`] instance using a [`vizia`][::vizia] GUI. The [`ViziaState`] passed to this
 /// function contains the GUI's intitial size, and this is kept in sync whenever the GUI gets
 /// resized. You can also use this to know if the GUI is open, so you can avoid performing
@@ -61,6 +63,7 @@ where
         scaling_factor: AtomicCell::new(Some(1.0)),
 
         emit_parameters_changed_event: Arc::new(AtomicBool::new(false)),
+        param_registry: ParamRegistry::new(),
     }))
 }
 

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -13,22 +13,18 @@ use vizia::prelude::*;
 
 use super::ViziaState;
 
+mod generic_ui;
 pub mod param_base;
 mod param_button;
 pub mod param_registry;
+mod param_slider;
+mod peak_meter;
 pub mod util;
 
-// SPIKE: generic_ui, param_slider, and peak_meter still reference the old Lens API and are
-// temporarily disabled while we validate the ParamWidgetBase signal port against a single
-// consumer (param_button). They will be ported in a follow-up once the base shape is confirmed.
-// mod generic_ui;
-// mod param_slider;
-// mod peak_meter;
-
+pub use generic_ui::GenericUi;
 pub use param_button::{ParamButton, ParamButtonExt};
-// pub use generic_ui::GenericUi;
-// pub use param_slider::{ParamSlider, ParamSliderExt, ParamSliderStyle};
-// pub use peak_meter::PeakMeter;
+pub use param_slider::{ParamSlider, ParamSliderExt, ParamSliderStyle};
+pub use peak_meter::PeakMeter;
 
 /// Register the default theme for the widgets exported by this module. This is automatically called
 /// for you when using [`create_vizia_editor()`][super::create_vizia_editor()].

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -13,17 +13,22 @@ use vizia::prelude::*;
 
 use super::ViziaState;
 
-mod generic_ui;
 pub mod param_base;
 mod param_button;
-mod param_slider;
-mod peak_meter;
+pub mod param_registry;
 pub mod util;
 
-pub use generic_ui::GenericUi;
+// SPIKE: generic_ui, param_slider, and peak_meter still reference the old Lens API and are
+// temporarily disabled while we validate the ParamWidgetBase signal port against a single
+// consumer (param_button). They will be ported in a follow-up once the base shape is confirmed.
+// mod generic_ui;
+// mod param_slider;
+// mod peak_meter;
+
 pub use param_button::{ParamButton, ParamButtonExt};
-pub use param_slider::{ParamSlider, ParamSliderExt, ParamSliderStyle};
-pub use peak_meter::PeakMeter;
+// pub use generic_ui::GenericUi;
+// pub use param_slider::{ParamSlider, ParamSliderExt, ParamSliderStyle};
+// pub use peak_meter::PeakMeter;
 
 /// Register the default theme for the widgets exported by this module. This is automatically called
 /// for you when using [`create_vizia_editor()`][super::create_vizia_editor()].
@@ -114,7 +119,6 @@ pub(crate) struct ParamModel {
 
 /// Handles interactions through `WindowEvent` for VIZIA GUIs by updating the `ViziaState`.
 /// Registered in [`ViziaEditor::spawn()`][super::ViziaEditor::spawn()].
-#[derive(Lens)]
 pub(crate) struct WindowModel {
     pub context: Arc<dyn GuiContext>,
     pub vizia_state: Arc<ViziaState>,

--- a/src/widgets/generic_ui.rs
+++ b/src/widgets/generic_ui.rs
@@ -5,59 +5,57 @@ use vizia::prelude::*;
 
 use super::{ParamSlider, ParamSliderExt, ParamSliderStyle};
 
-/// Shows a generic UI for a [`Params`] object. For additional flexibility you can either use the
-/// [`new()`][`Self::new()`] method to have the generic UI decide which widget to use for your
-/// parameters, or you can use the [`new_custom()`][`Self::new_custom()`] method to determine this
-/// yourself.
+/// Shows a generic UI for a [`Params`] object. For additional flexibility use
+/// [`new_custom`](Self::new_custom) to override the widget chosen for each parameter.
 pub struct GenericUi;
 
 impl GenericUi {
-    /// Creates a new [`GenericUi`] for all provided parameters. Use
-    /// [`new_custom()`][Self::new_custom()] to decide which widget gets used for each parameter.
+    /// Creates a new [`GenericUi`] for all parameters on the given `Params` object. Use
+    /// [`new_custom`](Self::new_custom) to decide which widget gets used for each parameter.
     ///
-    /// Wrap this in a [`ScrollView`] for plugins with longer parameter lists:
+    /// `params` only needs to outlive the call (not the whole widget lifetime): the builder
+    /// calls `params.param_map()` once up-front to enumerate the parameters and never holds
+    /// onto `params` after that. The individual parameter widgets (e.g. [`ParamSlider`]) are
+    /// constructed via `unsafe { &*p }` off of the `ParamPtr`s returned by `param_map`, which
+    /// relies on the plugin's `Arc<Params>` outliving the editor — same as everywhere else in
+    /// vizia-plug.
+    ///
+    /// Wrap this in a [`ScrollView`] for plugins with long parameter lists:
     ///
     /// ```ignore
     /// ScrollView::new(cx, 0.0, 0.0, false, true, |cx| {
-    ///     GenericUi::new(cx, Data::params);
+    ///     GenericUi::new(cx, &*params);
     /// })
     /// .width(Percentage(100.0));
-    ///```
-    pub fn new<L, PsRef, Ps>(cx: &mut Context, params: L) -> Handle<'_, GenericUi>
+    /// ```
+    pub fn new<'c, Ps>(cx: &'c mut Context, params: &Ps) -> Handle<'c, GenericUi>
     where
-        L: Lens<Target = PsRef> + Clone,
-        PsRef: AsRef<Ps> + 'static,
         Ps: Params + 'static,
     {
-        // Basic styling is done in the `theme.css` style sheet
+        // Basic styling is done in the `theme.css` style sheet.
         Self::new_custom(cx, params, move |cx, param_ptr| {
             HStack::new(cx, |cx| {
                 // Align this on the right
                 Label::new(cx, unsafe { param_ptr.name() }).class("label");
 
-                Self::draw_widget(cx, params, param_ptr);
+                Self::draw_widget(cx, param_ptr);
             })
             .class("row");
         })
     }
 
-    /// Creates a new [`GenericUi`] for all provided parameters using a custom closure that receives
-    /// a function that should draw some widget for each parameter.
-    pub fn new_custom<L, PsRef, Ps>(
-        cx: &mut Context,
-        params: L,
+    /// Creates a new [`GenericUi`] using a custom closure that draws the widget for each
+    /// parameter.
+    pub fn new_custom<'c, Ps>(
+        cx: &'c mut Context,
+        params: &Ps,
         mut make_widget: impl FnMut(&mut Context, ParamPtr),
-    ) -> Handle<Self>
+    ) -> Handle<'c, Self>
     where
-        L: Lens<Target = PsRef>,
-        PsRef: AsRef<Ps> + 'static,
         Ps: Params + 'static,
     {
-        // Basic styling is done in the `theme.css` style sheet
         Self.build(cx, |cx| {
-            // Rust does not have existential types, otherwise we could have passed functions that
-            // map `params` to some `impl Param` and everything would have been a lot neater
-            let param_map = params.map(|params| params.as_ref().param_map()).get(cx);
+            let param_map = params.param_map();
             for (_, param_ptr, _) in param_map {
                 let flags = unsafe { param_ptr.flags() };
                 if flags.contains(ParamFlags::HIDE_IN_GENERIC_UI) {
@@ -69,35 +67,35 @@ impl GenericUi {
         })
     }
 
-    /// The standard widget drawing function. This can be used together with `.new_custom()` to only
-    /// draw the labels differently.
-    pub fn draw_widget<L, PsRef, Ps>(cx: &mut Context, params: L, param_ptr: ParamPtr)
-    where
-        L: Lens<Target = PsRef>,
-        PsRef: AsRef<Ps> + 'static,
-        Ps: Params + 'static,
-    {
-        unsafe {
+    /// The standard widget-drawing function. Use with [`new_custom`](Self::new_custom) to keep
+    /// the default widget choice while customising the surrounding label.
+    pub fn draw_widget(cx: &mut Context, param_ptr: ParamPtr) {
+        // SAFETY: the `*mut P` raw pointers inside `ParamPtr` come from the plugin's pinned
+        // `Params` struct (held behind an `Arc`), so the `&P` borrows below are valid for the
+        // plugin's entire lifetime.
+        let handle = unsafe {
             match param_ptr {
-                ParamPtr::FloatParam(p) => ParamSlider::new(cx, params, move |_| &*p),
-                ParamPtr::IntParam(p) => ParamSlider::new(cx, params, move |_| &*p),
-                ParamPtr::BoolParam(p) => ParamSlider::new(cx, params, move |_| &*p),
-                ParamPtr::EnumParam(p) => ParamSlider::new(cx, params, move |_| &*p),
+                ParamPtr::FloatParam(p) => ParamSlider::new(cx, &*p),
+                ParamPtr::IntParam(p) => ParamSlider::new(cx, &*p),
+                ParamPtr::BoolParam(p) => ParamSlider::new(cx, &*p),
+                ParamPtr::EnumParam(p) => ParamSlider::new(cx, &*p),
             }
-        }
-        .set_style(match unsafe { param_ptr.step_count() } {
-            // This looks nice for boolean values, but it's too crowded for anything beyond
-            // that without making the widget wider
-            Some(step_count) if step_count <= 1 => {
-                ParamSliderStyle::CurrentStepLabeled { even: true }
-            }
-            Some(step_count) if step_count <= 2 => ParamSliderStyle::CurrentStep { even: true },
-            Some(_) => ParamSliderStyle::FromLeft,
-            // This is already the default, but continuous parameters should be drawn from
-            // the center if the default is also centered, or from the left if it is not
-            None => ParamSliderStyle::Centered,
-        })
-        .class("widget");
+        };
+
+        handle
+            .set_style(match unsafe { param_ptr.step_count() } {
+                // This looks nice for boolean values, but gets too crowded for anything beyond
+                // that without making the widget wider.
+                Some(step_count) if step_count <= 1 => {
+                    ParamSliderStyle::CurrentStepLabeled { even: true }
+                }
+                Some(step_count) if step_count <= 2 => ParamSliderStyle::CurrentStep { even: true },
+                Some(_) => ParamSliderStyle::FromLeft,
+                // Default. Continuous parameters are drawn from the centre if the default is
+                // also centred, or from the left if it is not.
+                None => ParamSliderStyle::Centered,
+            })
+            .class("widget");
     }
 }
 

--- a/src/widgets/generic_ui.rs
+++ b/src/widgets/generic_ui.rs
@@ -36,7 +36,9 @@ impl GenericUi {
         Self::new_custom(cx, params, move |cx, param_ptr| {
             HStack::new(cx, |cx| {
                 // Align this on the right
-                Label::new(cx, unsafe { param_ptr.name() }).class("label");
+                // `Label::new` takes `impl Res<T> + 'static` — `param_ptr.name()` returns
+                // a borrowed `&str`, so we own it here for the static-lifetime bound.
+                Label::new(cx, unsafe { param_ptr.name() }.to_owned()).class("label");
 
                 Self::draw_widget(cx, param_ptr);
             })

--- a/src/widgets/param_base.rs
+++ b/src/widgets/param_base.rs
@@ -93,6 +93,23 @@ impl ParamWidgetBase {
     ///
     /// Parameter changes are handled by emitting [`ParamEvent`](super::ParamEvent)s, which are
     /// automatically processed by the vizia-plug wrapper.
+    ///
+    /// # Wrapping `ParamWidgetBase` in a custom widget
+    ///
+    /// A consumer widget that wraps `ParamWidgetBase` in its own generic constructor needs to
+    /// spell out the `'p: 'c` bound (the parameter borrow must outlive the context borrow):
+    ///
+    /// ```ignore
+    /// pub fn new<'c, 'p, P>(cx: &'c mut Context, param: &'p P) -> Handle<'c, Self>
+    /// where
+    ///     'p: 'c,
+    ///     P: Param + 'static,
+    /// {
+    ///     let param_base = ParamWidgetBase::new(cx, param);
+    ///     // ... build the view tree, pass `param` through to any nested
+    ///     // `ParamWidgetBase::view` / `build_view` calls ...
+    /// }
+    /// ```
     pub fn new<P: Param>(_cx: &Context, param: &P) -> Self {
         Self { param_ptr: param.as_ptr() }
     }

--- a/src/widgets/param_base.rs
+++ b/src/widgets/param_base.rs
@@ -1,94 +1,79 @@
 //! A base widget for creating other widgets that integrate with NIH-plug's [`Param`] types.
 
+use std::sync::Arc;
+
 use nih_plug::prelude::*;
 use vizia::prelude::*;
 
+use super::param_registry::{ParamAxis, ParamRegistry};
 use super::RawParamEvent;
 
-/// A helper for creating parameter widgets. The general idea is that a parameter widget struct can
-/// adds a `ParamWidgetBase` field on its struct, and then calls [`ParamWidgetBase::view()`] in its
-/// view build function. The stored `ParamWidgetbBase` object can then be used in the widget's event
-/// handlers to interact with the parameter.
-#[derive(Lens)]
+/// A helper for creating parameter widgets. The general idea is that a parameter widget struct
+/// adds a [`ParamWidgetBase`] field on its struct, and then calls [`ParamWidgetBase::view`] in its
+/// view build function. The stored `ParamWidgetBase` object can then be used in the widget's event
+/// handlers to interact with the parameter, and provides accessors (via
+/// [`ParamWidgetBase::modulated_signal`] / [`ParamWidgetBase::unmodulated_signal`]) for binding
+/// the parameter's current value into views.
+///
+/// Signals are owned by the editor's [`ParamRegistry`] model and shared across all widgets that
+/// reference the same parameter.
 pub struct ParamWidgetBase {
-    /// We're not allowed to store a reference to the parameter internally, at least not in the
-    /// struct that implements [`View`].
+    /// Opaque handle to the parameter. Stable for the lifetime of the plugin; safe to copy and
+    /// re-use across widget instances.
     param_ptr: ParamPtr,
 }
 
-/// Data and lenses that can be used to draw the parameter widget. The [`param`][Self::param] field
-/// should only be used for looking up static data. Prefer the [`make_lens()`][Self::make_lens()]
-/// function for binding parameter data to element properties.
-pub struct ParamWidgetData<L, Params, P, FMap>
-where
-    L: Lens<Target = Params> + Clone,
-    Params: 'static,
-    P: Param + 'static,
-    FMap: Fn(&Params) -> &P + Copy + 'static,
-{
-    // HACK: This needs to be a static reference because of the way bindings in Vizia works. This
-    //       feels very wrong, but I don't think there is an alternative. The field is not `pub`
-    //       for this reason.
+/// Data and signal accessors that can be used to draw the parameter widget. The [`param`][Self::param]
+/// field should only be used for looking up static data (parameter name, step count, formatters).
+/// For binding live values to view properties, use the `signal` accessors which return
+/// [`SyncSignal<f32>`]s tracked by the reactive graph.
+pub struct ParamWidgetData<P: Param + 'static> {
+    // HACK: This needs to be a static reference because of the way bindings in vizia work. The
+    //       field is not `pub` for this reason — widgets access it via `ParamWidgetData::param()`.
     param: &'static P,
-    params: L,
-    params_to_param: FMap,
+    param_ptr: ParamPtr,
 }
 
-impl<L, Params, P, FMap> Clone for ParamWidgetData<L, Params, P, FMap>
-where
-    L: Lens<Target = Params> + Clone,
-    Params: 'static,
-    P: Param + 'static,
-    FMap: Fn(&Params) -> &P + Copy + 'static,
-{
+impl<P: Param + 'static> Clone for ParamWidgetData<P> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<L, Params, P, FMap> Copy for ParamWidgetData<L, Params, P, FMap>
-where
-    L: Lens<Target = Params> + Copy,
-    Params: 'static,
-    P: Param + 'static,
-    FMap: Fn(&Params) -> &P + Copy + 'static,
-{
-}
+impl<P: Param + 'static> Copy for ParamWidgetData<P> {}
 
-impl<L, Params, P, FMap> ParamWidgetData<L, Params, P, FMap>
-where
-    L: Lens<Target = Params> + Clone,
-    Params: 'static,
-    P: Param + 'static,
-    FMap: Fn(&Params) -> &P + Copy + 'static,
-{
-    /// The parameter in question. This can be used for querying static information about the
-    /// parameter. Don't use this to get the parameter's current value, use the lenses instead.
+impl<P: Param + 'static> ParamWidgetData<P> {
+    /// The parameter in question. Use for querying static information (name, unit, step count,
+    /// formatters). Don't use this to read the parameter's current value — use
+    /// [`modulated_signal`][Self::modulated_signal] instead so the reactive graph can track the
+    /// dependency.
     pub fn param(&self) -> &P {
         self.param
     }
 
-    /// Create a lens from a parameter's field. This can be used to bind one of the parameter's
-    /// value getters to a property.
-    pub fn make_lens<R, F>(&self, f: F) -> impl Lens<Target = R>
-    where
-        F: Fn(&P) -> R + Clone + 'static,
-        R: Clone + 'static,
-    {
-        let params_to_param = self.params_to_param;
+    /// The underlying [`ParamPtr`] for this parameter. Widgets don't usually need this directly;
+    /// prefer the signal accessors or the action methods on [`ParamWidgetBase`].
+    pub fn param_ptr(&self) -> ParamPtr {
+        self.param_ptr
+    }
 
-        self.params.map(move |params| {
-            let param = params_to_param(params);
-            f(param)
-        })
+    /// Signal tracking the parameter's modulated normalised value. This is what the user sees
+    /// driving the audio; most widgets should bind to this.
+    pub fn modulated_signal(&self, cx: &Context) -> SyncSignal<f32> {
+        registry(cx).modulated(self.param_ptr)
+    }
+
+    /// Signal tracking the parameter's unmodulated (user/host-set) normalised value. Useful when
+    /// a widget needs to distinguish the user-set value from host modulation.
+    pub fn unmodulated_signal(&self, cx: &Context) -> SyncSignal<f32> {
+        registry(cx).unmodulated(self.param_ptr)
     }
 }
 
-/// Generate a [`ParamWidgetData`] function that forwards the function call to the underlying
-/// `ParamPtr`.
+/// Generate a [`ParamWidgetBase`] method that forwards the call to the underlying [`ParamPtr`].
 macro_rules! param_ptr_forward(
     (pub fn $method:ident(&self $(, $arg_name:ident: $arg_ty:ty)*) -> $ret:ty) => {
-        /// Calls the corresponding method on the underlying [`ParamPtr`] object.
+        /// Calls the corresponding method on the underlying [`ParamPtr`].
         pub fn $method(&self $(, $arg_name: $arg_ty)*) -> $ret {
             unsafe { self.param_ptr.$method($($arg_name),*) }
         }
@@ -96,132 +81,113 @@ macro_rules! param_ptr_forward(
 );
 
 impl ParamWidgetBase {
-    /// Creates a [`ParamWidgetBase`] for the given parameter. This can be stored on a widget object
-    /// and used as part of the widget's event handling. To accommodate VIZIA's mapping system,
-    /// you'll need to provide a lens containing your `Params` implementation object (check out how
-    /// the `Data` struct is used in `gain_gui_vizia`) and a projection function that maps the
-    /// `Params` object to the parameter you want to display a widget for. Parameter changes are
-    /// handled by emitting [`ParamEvent`][super::ParamEvent]s which are automatically handled by
-    /// the VIZIA wrapper.
-    pub fn new<L, Params, P, FMap>(cx: &Context, params: L, params_to_param: FMap) -> Self
+    /// Creates a [`ParamWidgetBase`] for the given parameter. Parameter changes are handled by
+    /// emitting [`ParamEvent`][super::ParamEvent]s, which are automatically processed by the
+    /// vizia-plug wrapper.
+    ///
+    /// `params` is a shared reference to the plugin's `Params` struct; `params_to_param` projects
+    /// into the specific parameter you want this widget to drive. The `Params` reference is only
+    /// used at construction time to resolve the opaque [`ParamPtr`]; widgets hold onto the pointer
+    /// and use signals from the editor's [`ParamRegistry`] for live values.
+    pub fn new<Params, P, FMap>(
+        _cx: &Context,
+        params: Arc<Params>,
+        params_to_param: FMap,
+    ) -> Self
     where
-        L: Lens<Target = Params> + Clone,
         Params: 'static,
         P: Param,
-        FMap: Fn(&Params) -> &P + Copy + 'static,
+        FMap: Fn(&Params) -> &P,
     {
-        // We need to do a bit of a nasty and erase the lifetime bound by going through a raw
-        // ParamPtr. Vizia requires all lens data to be 'static and Clone.
-        let param_ptr = params
-            .map(move |params| params_to_param(params).as_ptr())
-            .get(cx);
-
+        let param_ptr = params_to_param(&params).as_ptr();
         Self { param_ptr }
     }
 
-    /// Create a view using the a parameter's data. This is not tied to a particular
-    /// [`ParamWidgetBase`] instance, but it allows you to easily create lenses for the parameter's
-    /// values and access static parameter data.
-    pub fn view<L, Params, P, FMap, F, R>(
+    /// Create a view using the parameter's data. The `content` closure receives a
+    /// [`ParamWidgetData`] that gives access to static parameter metadata and to signals for
+    /// binding live values.
+    ///
+    /// SAFETY: The `&'static P` made available via [`ParamWidgetData::param`] does not actually
+    /// outlive the call — but in the vizia-plug setup the `&P` outlives the editor (the plugin's
+    /// `Params` struct is pinned for the plugin's lifetime). This mirrors the pre-signal API.
+    pub fn view<Params, P, FMap, F, R>(
         cx: &mut Context,
-        params: L,
+        params: Arc<Params>,
         params_to_param: FMap,
         content: F,
     ) -> R
     where
-        L: Lens<Target = Params> + Clone,
         Params: 'static,
         P: Param + 'static,
-        FMap: Fn(&Params) -> &P + Copy + 'static,
-        F: FnOnce(&mut Context, ParamWidgetData<L, Params, P, FMap>) -> R,
+        FMap: Fn(&Params) -> &P,
+        F: FnOnce(&mut Context, ParamWidgetData<P>) -> R,
     {
-        // We'll provide the raw `&P` to the callbacks to make creating parameter widgets more
-        // convenient.
-        // SAFETY: This &P won't outlive this function, and in the context of NIH-plug &P will
-        //         outlive the editor
-        let param: &P = unsafe {
-            &*params
-                .map(move |params| params_to_param(params) as *const P)
-                .get(cx)
-        };
+        // SAFETY: see function docs.
+        let param_ref = params_to_param(&params);
+        let param_ptr = param_ref.as_ptr();
+        let param: &'static P = unsafe { &*(param_ref as *const P) };
 
-        // The widget can use this to access data parameter data and to create lenses for working
-        // with the parameter's values
-        let param_data = ParamWidgetData {
-            param,
-            params,
-            params_to_param,
-        };
-
+        let param_data = ParamWidgetData { param, param_ptr };
         content(cx, param_data)
     }
 
-    /// A shorthand for [`view()`][Self::view()] that can be used directly as an argument to
-    /// [`View::build()`].
-    pub fn build_view<L, Params, P, FMap, F, R>(
-        params: L,
+    /// Shorthand for [`view`][Self::view] that returns a closure suitable for
+    /// [`View::build`](vizia::prelude::View::build).
+    pub fn build_view<Params, P, FMap, F, R>(
+        params: Arc<Params>,
         params_to_param: FMap,
         content: F,
     ) -> impl FnOnce(&mut Context) -> R
     where
-        L: Lens<Target = Params> + Clone,
         Params: 'static,
         P: Param + 'static,
-        FMap: Fn(&Params) -> &P + Copy + 'static,
-        F: FnOnce(&mut Context, ParamWidgetData<L, Params, P, FMap>) -> R,
+        FMap: Fn(&Params) -> &P + 'static,
+        F: FnOnce(&mut Context, ParamWidgetData<P>) -> R,
     {
         move |cx| Self::view(cx, params, params_to_param, content)
     }
 
-    /// Convenience function for using [`ParamWidgetData::make_lens()`]. Whenever possible,
-    /// [`view()`][Self::view()] should be used instead.
-    pub fn make_lens<L, Params, P, FMap, F, R>(
-        params: L,
-        params_to_param: FMap,
-        f: F,
-    ) -> impl Lens<Target = R>
-    where
-        L: Lens<Target = Params> + Clone,
-        Params: 'static,
-        P: Param + 'static,
-        FMap: Fn(&Params) -> &P + Copy + 'static,
-        F: Fn(&P) -> R + Clone + 'static,
-        R: Clone + 'static,
-    {
-        params.map(move |params| {
-            let param = params_to_param(params);
-            f(param)
-        })
+    /// Returns the signal tracking this widget's parameter on the given axis. Widgets can bind
+    /// view properties to this signal directly, or wrap it in a [`Memo`] for derived values.
+    pub fn signal(&self, cx: &Context, axis: ParamAxis) -> SyncSignal<f32> {
+        registry(cx).signal(self.param_ptr, axis)
     }
 
-    /// Start an automation gesture. This **must** be called before `set_normalized_value()`
-    /// is called. Usually this is done on mouse down.
+    /// Shorthand for `signal(cx, ParamAxis::Modulated)` — the value most widgets want to display.
+    pub fn modulated_signal(&self, cx: &Context) -> SyncSignal<f32> {
+        registry(cx).modulated(self.param_ptr)
+    }
+
+    /// Shorthand for `signal(cx, ParamAxis::Unmodulated)`.
+    pub fn unmodulated_signal(&self, cx: &Context) -> SyncSignal<f32> {
+        registry(cx).unmodulated(self.param_ptr)
+    }
+
+    /// The [`ParamPtr`] backing this widget. Usually not needed directly.
+    pub fn param_ptr(&self) -> ParamPtr {
+        self.param_ptr
+    }
+
+    /// Start an automation gesture. **Must** be called before [`set_normalized_value`][Self::set_normalized_value];
+    /// typically fired on mouse-down.
     pub fn begin_set_parameter(&self, cx: &mut EventContext) {
         cx.emit(RawParamEvent::BeginSetParameter(self.param_ptr));
     }
 
-    /// Set the normalized value for a parameter if that would change the parameter's plain value
-    /// (to avoid unnecessary duplicate parameter changes). `begin_set_parameter()` **must** be
-    /// called before this is called to start an automation gesture, and `end_set_parameter()` must
-    /// be called at the end of the gesture.
+    /// Set the normalised value for a parameter. Must be wrapped in matching
+    /// [`begin_set_parameter`][Self::begin_set_parameter] /
+    /// [`end_set_parameter`][Self::end_set_parameter] calls.
     pub fn set_normalized_value(&self, cx: &mut EventContext, normalized_value: f32) {
-        // This snaps to the nearest plain value if the parameter is stepped in some way.
-        // TODO: As an optimization, we could add a `const CONTINUOUS: bool` to the parameter to
-        //       avoid this normalized->plain->normalized conversion for parameters that don't need
-        //       it
+        // Snap to the nearest plain value for stepped params.
         let plain_value = unsafe { self.param_ptr.preview_plain(normalized_value) };
-        
-            // For the aforementioned snapping
-            let normalized_plain_value = unsafe { self.param_ptr.preview_normalized(plain_value) };
-            cx.emit(RawParamEvent::SetParameterNormalized(
-                self.param_ptr,
-                normalized_plain_value,
-            ));
-        
+        let normalized_plain_value = unsafe { self.param_ptr.preview_normalized(plain_value) };
+        cx.emit(RawParamEvent::SetParameterNormalized(
+            self.param_ptr,
+            normalized_plain_value,
+        ));
     }
 
-    /// End an automation gesture. This must be called at the end of a gesture, after zero or more
-    /// `set_normalized_value()` calls. Usually this is done on mouse down.
+    /// End an automation gesture. Typically fired on mouse-up.
     pub fn end_set_parameter(&self, cx: &mut EventContext) {
         cx.emit(RawParamEvent::EndSetParameter(self.param_ptr));
     }
@@ -243,4 +209,11 @@ impl ParamWidgetBase {
     param_ptr_forward!(pub fn preview_normalized(&self, plain: f32) -> f32);
     param_ptr_forward!(pub fn preview_plain(&self, normalized: f32) -> f32);
     param_ptr_forward!(pub fn flags(&self) -> ParamFlags);
+}
+
+/// Look up the [`ParamRegistry`] installed on the editor root. Panics (via
+/// [`Context::data`]'s own assertion) if no registry is found, which indicates the editor was
+/// not created via [`create_vizia_editor`][crate::create_vizia_editor].
+fn registry(cx: &Context) -> &ParamRegistry {
+    cx.data::<ParamRegistry>()
 }

--- a/src/widgets/param_base.rs
+++ b/src/widgets/param_base.rs
@@ -1,7 +1,5 @@
 //! A base widget for creating other widgets that integrate with NIH-plug's [`Param`] types.
 
-use std::sync::Arc;
-
 use nih_plug::prelude::*;
 use vizia::prelude::*;
 
@@ -9,50 +7,57 @@ use super::param_registry::{ParamAxis, ParamRegistry};
 use super::RawParamEvent;
 
 /// A helper for creating parameter widgets. The general idea is that a parameter widget struct
-/// adds a [`ParamWidgetBase`] field on its struct, and then calls [`ParamWidgetBase::view`] in its
-/// view build function. The stored `ParamWidgetBase` object can then be used in the widget's event
-/// handlers to interact with the parameter, and provides accessors (via
-/// [`ParamWidgetBase::modulated_signal`] / [`ParamWidgetBase::unmodulated_signal`]) for binding
-/// the parameter's current value into views.
+/// stores a [`ParamWidgetBase`] field, calls [`ParamWidgetBase::view`] in its build function,
+/// and uses the base's action methods ([`begin_set_parameter`](Self::begin_set_parameter),
+/// [`set_normalized_value`](Self::set_normalized_value),
+/// [`end_set_parameter`](Self::end_set_parameter)) in its event handlers.
 ///
-/// Signals are owned by the editor's [`ParamRegistry`] model and shared across all widgets that
-/// reference the same parameter.
+/// Signals for a parameter's live values are owned by the editor's [`ParamRegistry`] model and
+/// shared across every widget that targets the same parameter, so binding a label and a knob to
+/// the same parameter costs a single `SyncSignal<f32>`.
+///
+/// `ParamWidgetBase` is `Copy` because its entire state is a [`ParamPtr`]. Widgets can freely
+/// capture a copy into any `'static` closure (e.g. a `Binding::new` builder) without dragging a
+/// borrow of the user's `Params` struct along with it.
+#[derive(Clone, Copy)]
 pub struct ParamWidgetBase {
-    /// Opaque handle to the parameter. Stable for the lifetime of the plugin; safe to copy and
-    /// re-use across widget instances.
+    /// Opaque handle to the parameter. Stable for the lifetime of the plugin; `Copy`, so safe to
+    /// reuse across widget instances.
     param_ptr: ParamPtr,
 }
 
-/// Data and signal accessors that can be used to draw the parameter widget. The [`param`][Self::param]
-/// field should only be used for looking up static data (parameter name, step count, formatters).
-/// For binding live values to view properties, use the `signal` accessors which return
-/// [`SyncSignal<f32>`]s tracked by the reactive graph.
-pub struct ParamWidgetData<P: Param + 'static> {
-    // HACK: This needs to be a static reference because of the way bindings in vizia work. The
-    //       field is not `pub` for this reason — widgets access it via `ParamWidgetData::param()`.
-    param: &'static P,
+/// Data and signal accessors passed to the build closure in
+/// [`ParamWidgetBase::view`] / [`ParamWidgetBase::build_view`]. Carries a borrow of the parameter
+/// for typed access to static metadata (name, step count, formatters) plus lazy accessors for
+/// the registry-owned signals that track live values.
+///
+/// The `'a` lifetime matches the borrow passed into `view` / `build_view`. In the normal
+/// vizia-plug setup the plugin's `Params` struct is pinned for the plugin's lifetime via
+/// `Arc<Params>`, so a borrow of a specific parameter inside it easily outlives any widget that
+/// refers to it.
+pub struct ParamWidgetData<'a, P: Param + 'static> {
+    param: &'a P,
     param_ptr: ParamPtr,
 }
 
-impl<P: Param + 'static> Clone for ParamWidgetData<P> {
+impl<P: Param + 'static> Clone for ParamWidgetData<'_, P> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<P: Param + 'static> Copy for ParamWidgetData<P> {}
+impl<P: Param + 'static> Copy for ParamWidgetData<'_, P> {}
 
-impl<P: Param + 'static> ParamWidgetData<P> {
-    /// The parameter in question. Use for querying static information (name, unit, step count,
-    /// formatters). Don't use this to read the parameter's current value — use
-    /// [`modulated_signal`][Self::modulated_signal] instead so the reactive graph can track the
-    /// dependency.
-    pub fn param(&self) -> &P {
+impl<'a, P: Param + 'static> ParamWidgetData<'a, P> {
+    /// The parameter itself. Use for static information (name, unit, step count, formatters). For
+    /// reading the live value, use [`modulated_signal`](Self::modulated_signal) instead so the
+    /// reactive graph can track the dependency.
+    pub fn param(&self) -> &'a P {
         self.param
     }
 
-    /// The underlying [`ParamPtr`] for this parameter. Widgets don't usually need this directly;
-    /// prefer the signal accessors or the action methods on [`ParamWidgetBase`].
+    /// The underlying [`ParamPtr`]. Widgets don't usually need this directly; prefer the signal
+    /// accessors or the action methods on [`ParamWidgetBase`].
     pub fn param_ptr(&self) -> ParamPtr {
         self.param_ptr
     }
@@ -81,74 +86,47 @@ macro_rules! param_ptr_forward(
 );
 
 impl ParamWidgetBase {
-    /// Creates a [`ParamWidgetBase`] for the given parameter. Parameter changes are handled by
-    /// emitting [`ParamEvent`][super::ParamEvent]s, which are automatically processed by the
-    /// vizia-plug wrapper.
+    /// Creates a [`ParamWidgetBase`] for the given parameter. The reference is only used at
+    /// construction time to resolve the parameter's opaque [`ParamPtr`] — the widget does not
+    /// keep a borrow of it. Callers typically pass a field of their `Params` struct, e.g.
+    /// `ParamSlider::new(cx, &params.gain)`.
     ///
-    /// `params` is a shared reference to the plugin's `Params` struct; `params_to_param` projects
-    /// into the specific parameter you want this widget to drive. The `Params` reference is only
-    /// used at construction time to resolve the opaque [`ParamPtr`]; widgets hold onto the pointer
-    /// and use signals from the editor's [`ParamRegistry`] for live values.
-    pub fn new<Params, P, FMap>(
-        _cx: &Context,
-        params: Arc<Params>,
-        params_to_param: FMap,
-    ) -> Self
-    where
-        Params: 'static,
-        P: Param,
-        FMap: Fn(&Params) -> &P,
-    {
-        let param_ptr = params_to_param(&params).as_ptr();
-        Self { param_ptr }
+    /// Parameter changes are handled by emitting [`ParamEvent`](super::ParamEvent)s, which are
+    /// automatically processed by the vizia-plug wrapper.
+    pub fn new<P: Param>(_cx: &Context, param: &P) -> Self {
+        Self { param_ptr: param.as_ptr() }
     }
 
     /// Create a view using the parameter's data. The `content` closure receives a
-    /// [`ParamWidgetData`] that gives access to static parameter metadata and to signals for
-    /// binding live values.
+    /// [`ParamWidgetData`] that gives typed access to the parameter (for static metadata) and
+    /// signals for binding live values.
     ///
-    /// SAFETY: The `&'static P` made available via [`ParamWidgetData::param`] does not actually
-    /// outlive the call — but in the vizia-plug setup the `&P` outlives the editor (the plugin's
-    /// `Params` struct is pinned for the plugin's lifetime). This mirrors the pre-signal API.
-    pub fn view<Params, P, FMap, F, R>(
-        cx: &mut Context,
-        params: Arc<Params>,
-        params_to_param: FMap,
-        content: F,
-    ) -> R
+    /// `param` only needs to outlive the call; the `'a` lifetime is carried through
+    /// [`ParamWidgetData`] so the builder closure can safely borrow it.
+    pub fn view<'a, P, F, R>(cx: &mut Context, param: &'a P, content: F) -> R
     where
-        Params: 'static,
         P: Param + 'static,
-        FMap: Fn(&Params) -> &P,
-        F: FnOnce(&mut Context, ParamWidgetData<P>) -> R,
+        F: FnOnce(&mut Context, ParamWidgetData<'a, P>) -> R,
     {
-        // SAFETY: see function docs.
-        let param_ref = params_to_param(&params);
-        let param_ptr = param_ref.as_ptr();
-        let param: &'static P = unsafe { &*(param_ref as *const P) };
-
-        let param_data = ParamWidgetData { param, param_ptr };
+        let param_data = ParamWidgetData { param, param_ptr: param.as_ptr() };
         content(cx, param_data)
     }
 
-    /// Shorthand for [`view`][Self::view] that returns a closure suitable for
+    /// Shorthand for [`view`](Self::view) that returns a builder closure suitable for
     /// [`View::build`](vizia::prelude::View::build).
-    pub fn build_view<Params, P, FMap, F, R>(
-        params: Arc<Params>,
-        params_to_param: FMap,
+    pub fn build_view<'a, P, F, R>(
+        param: &'a P,
         content: F,
-    ) -> impl FnOnce(&mut Context) -> R
+    ) -> impl FnOnce(&mut Context) -> R + 'a
     where
-        Params: 'static,
         P: Param + 'static,
-        FMap: Fn(&Params) -> &P + 'static,
-        F: FnOnce(&mut Context, ParamWidgetData<P>) -> R,
+        F: FnOnce(&mut Context, ParamWidgetData<'a, P>) -> R + 'a,
     {
-        move |cx| Self::view(cx, params, params_to_param, content)
+        move |cx| Self::view(cx, param, content)
     }
 
     /// Returns the signal tracking this widget's parameter on the given axis. Widgets can bind
-    /// view properties to this signal directly, or wrap it in a [`Memo`] for derived values.
+    /// view properties to this signal directly, or wrap it in a [`Memo`] for derived views.
     pub fn signal(&self, cx: &Context, axis: ParamAxis) -> SyncSignal<f32> {
         registry(cx).signal(self.param_ptr, axis)
     }
@@ -168,15 +146,15 @@ impl ParamWidgetBase {
         self.param_ptr
     }
 
-    /// Start an automation gesture. **Must** be called before [`set_normalized_value`][Self::set_normalized_value];
-    /// typically fired on mouse-down.
+    /// Start an automation gesture. **Must** be called before
+    /// [`set_normalized_value`](Self::set_normalized_value); typically fired on mouse-down.
     pub fn begin_set_parameter(&self, cx: &mut EventContext) {
         cx.emit(RawParamEvent::BeginSetParameter(self.param_ptr));
     }
 
     /// Set the normalised value for a parameter. Must be wrapped in matching
-    /// [`begin_set_parameter`][Self::begin_set_parameter] /
-    /// [`end_set_parameter`][Self::end_set_parameter] calls.
+    /// [`begin_set_parameter`](Self::begin_set_parameter) /
+    /// [`end_set_parameter`](Self::end_set_parameter) calls.
     pub fn set_normalized_value(&self, cx: &mut EventContext, normalized_value: f32) {
         // Snap to the nearest plain value for stepped params.
         let plain_value = unsafe { self.param_ptr.preview_plain(normalized_value) };
@@ -213,7 +191,7 @@ impl ParamWidgetBase {
 
 /// Look up the [`ParamRegistry`] installed on the editor root. Panics (via
 /// [`Context::data`]'s own assertion) if no registry is found, which indicates the editor was
-/// not created via [`create_vizia_editor`][crate::create_vizia_editor].
+/// not created via [`create_vizia_editor`](crate::create_vizia_editor).
 fn registry(cx: &Context) -> &ParamRegistry {
     cx.data::<ParamRegistry>()
 }

--- a/src/widgets/param_button.rs
+++ b/src/widgets/param_button.rs
@@ -54,7 +54,7 @@ impl ParamButton {
                 let param_name = param_data.param().name().to_owned();
                 Binding::new(cx, label_override, move |cx| {
                     let text = label_override.get().unwrap_or_else(|| param_name.clone());
-                    Label::new(cx, &text).hoverable(false);
+                    Label::new(cx, text).hoverable(false);
                 });
             }),
         )

--- a/src/widgets/param_button.rs
+++ b/src/widgets/param_button.rs
@@ -1,15 +1,13 @@
 //! A toggleable button that integrates with NIH-plug's [`Param`] types.
 
-use std::sync::Arc;
-
 use nih_plug::prelude::Param;
 use vizia::prelude::*;
 
 use super::param_base::ParamWidgetBase;
 
 /// A toggleable button that integrates with NIH-plug's [`Param`] types. Only makes sense with
-/// [`BoolParam`][nih_plug::prelude::BoolParam]s. Clicking on the button will toggle between the
-/// parameter's minimum and maximum value. The `:checked` pseudoclass indicates whether or not the
+/// [`BoolParam`][nih_plug::prelude::BoolParam]s. Clicking the button toggles between the
+/// parameter's minimum and maximum value. The `:checked` pseudoclass indicates whether the
 /// button is currently pressed.
 pub struct ParamButton {
     param_base: ParamWidgetBase,
@@ -17,31 +15,32 @@ pub struct ParamButton {
     // These fields are set through modifiers:
     /// Whether or not to listen to scroll events for changing the parameter's value in steps.
     use_scroll_wheel: bool,
-    /// A specific label to use instead of displaying the parameter's name.
+    /// A specific label to use instead of displaying the parameter's value. Wrapped in a signal
+    /// so the `.with_label` modifier can update it after construction and the label rebinds.
     label_override: SyncSignal<Option<String>>,
 
     /// The number of (fractional) scrolled lines that have not yet been turned into parameter
-    /// change events. This is needed to support trackpads with smooth scrolling.
+    /// change events. Supports trackpads with smooth scrolling.
     scrolled_lines: f32,
 }
 
 impl ParamButton {
-    /// Creates a new [`ParamButton`] for the given parameter. See
-    /// [`ParamSlider`][super::ParamSlider] for more information on this function's arguments.
-    pub fn new<Params, P, FMap>(
-        cx: &mut Context,
-        params: Arc<Params>,
-        params_to_param: FMap,
-    ) -> Handle<Self>
+    /// Creates a new [`ParamButton`] for the given parameter. Pass a reference to the
+    /// parameter directly — e.g. `ParamButton::new(cx, &params.my_toggle)`.
+    ///
+    /// The `'p: 'c` bound reads as "the parameter must outlive the context borrow": the
+    /// builder closure captured into `cx` borrows `param` to resolve static metadata, so the
+    /// parameter's storage (normally inside the plugin's `Arc<Params>`) has to stay alive at
+    /// least as long as the widget is being built. In practice this is always true — `Params`
+    /// lives for the plugin's lifetime — the bound just lets the borrow checker prove it.
+    pub fn new<'c, 'p, P>(cx: &'c mut Context, param: &'p P) -> Handle<'c, Self>
     where
-        Params: 'static,
+        'p: 'c,
         P: Param + 'static,
-        FMap: Fn(&Params) -> &P + Copy + 'static,
     {
-        let param_base = ParamWidgetBase::new(cx, params.clone(), params_to_param);
+        let param_base = ParamWidgetBase::new(cx, param);
         let modulated_signal = param_base.modulated_signal(cx);
-
-        let label_override = SyncSignal::new(None::<String>);
+        let label_override: SyncSignal<Option<String>> = SyncSignal::new(None);
 
         Self {
             param_base,
@@ -51,19 +50,16 @@ impl ParamButton {
         }
         .build(
             cx,
-            ParamWidgetBase::build_view(params, params_to_param, move |cx, param_data| {
+            ParamWidgetBase::build_view(param, move |cx, param_data| {
                 let param_name = param_data.param().name().to_owned();
                 Binding::new(cx, label_override, move |cx| {
-                    let text = label_override
-                        .get()
-                        .unwrap_or_else(|| param_name.clone());
+                    let text = label_override.get().unwrap_or_else(|| param_name.clone());
                     Label::new(cx, &text).hoverable(false);
                 });
             }),
         )
-        // We'll add the `:checked` pseudoclass when the button is pressed. This uses the modulated
-        // normalised value — there's no convenient way to display both modulated and unmodulated
-        // values for a button.
+        // `:checked` pseudo-class when the button is on. Uses modulated value — there's no
+        // convenient way to display both modulated and unmodulated for a button.
         .checked(modulated_signal.map(|v| *v >= 0.5))
     }
 
@@ -93,8 +89,7 @@ impl View for ParamButton {
                 meta.consume();
             }
             WindowEvent::MouseScroll(_scroll_x, scroll_y) if self.use_scroll_wheel => {
-                // With a regular scroll wheel `scroll_y` will only ever be -1 or 1, but with smooth
-                // scrolling trackpads being a thing `scroll_y` could be anything.
+                // A regular scroll wheel sends ±1; smooth-scrolling trackpads send anything.
                 self.scrolled_lines += scroll_y;
 
                 if self.scrolled_lines.abs() >= 1.0 {
@@ -120,8 +115,8 @@ impl View for ParamButton {
 
 /// Extension methods for [`ParamButton`] handles.
 pub trait ParamButtonExt {
-    /// Don't respond to scroll wheel events. Useful when this button is used as part of a
-    /// scrolling view.
+    /// Don't respond to scroll wheel events. Useful when the button sits inside a scrolling
+    /// container.
     fn disable_scroll_wheel(self) -> Self;
 
     /// Change the colour scheme for a bypass button. Adds the `bypass` CSS class.

--- a/src/widgets/param_button.rs
+++ b/src/widgets/param_button.rs
@@ -1,5 +1,7 @@
 //! A toggleable button that integrates with NIH-plug's [`Param`] types.
 
+use std::sync::Arc;
+
 use nih_plug::prelude::Param;
 use vizia::prelude::*;
 
@@ -9,15 +11,14 @@ use super::param_base::ParamWidgetBase;
 /// [`BoolParam`][nih_plug::prelude::BoolParam]s. Clicking on the button will toggle between the
 /// parameter's minimum and maximum value. The `:checked` pseudoclass indicates whether or not the
 /// button is currently pressed.
-#[derive(Lens)]
 pub struct ParamButton {
     param_base: ParamWidgetBase,
 
     // These fields are set through modifiers:
     /// Whether or not to listen to scroll events for changing the parameter's value in steps.
     use_scroll_wheel: bool,
-    /// A specific label to use instead of displaying the parameter's value.
-    label_override: Option<String>,
+    /// A specific label to use instead of displaying the parameter's name.
+    label_override: SyncSignal<Option<String>>,
 
     /// The number of (fractional) scrolled lines that have not yet been turned into parameter
     /// change events. This is needed to support trackpads with smooth scrolling.
@@ -27,48 +28,46 @@ pub struct ParamButton {
 impl ParamButton {
     /// Creates a new [`ParamButton`] for the given parameter. See
     /// [`ParamSlider`][super::ParamSlider] for more information on this function's arguments.
-    pub fn new<L, Params, P, FMap>(
+    pub fn new<Params, P, FMap>(
         cx: &mut Context,
-        params: L,
+        params: Arc<Params>,
         params_to_param: FMap,
     ) -> Handle<Self>
     where
-        L: Lens<Target = Params> + Clone,
         Params: 'static,
         P: Param + 'static,
         FMap: Fn(&Params) -> &P + Copy + 'static,
     {
+        let param_base = ParamWidgetBase::new(cx, params.clone(), params_to_param);
+        let modulated_signal = param_base.modulated_signal(cx);
+
+        let label_override = SyncSignal::new(None::<String>);
+
         Self {
-            param_base: ParamWidgetBase::new(cx, params, params_to_param),
-
+            param_base,
             use_scroll_wheel: true,
-            label_override: None,
-
+            label_override,
             scrolled_lines: 0.0,
         }
         .build(
             cx,
             ParamWidgetBase::build_view(params, params_to_param, move |cx, param_data| {
-                Binding::new(cx, Self::label_override, move |cx, label_override| {
-                    match label_override.get(cx) {
-                        Some(label_override) => Label::new(cx, &label_override),
-                        None => Label::new(cx, param_data.param().name()),
-                    }
-                    .hoverable(false);
-                })
+                let param_name = param_data.param().name().to_owned();
+                Binding::new(cx, label_override, move |cx| {
+                    let text = label_override
+                        .get()
+                        .unwrap_or_else(|| param_name.clone());
+                    Label::new(cx, &text).hoverable(false);
+                });
             }),
         )
-        // We'll add the `:checked` pseudoclass when the button is pressed
-        // NOTE: We use the normalized value _with modulation_ for this. There's no convenient way
-        //       to show both modulated and unmodulated values here.
-        .checked(ParamWidgetBase::make_lens(
-            params,
-            params_to_param,
-            |param| param.modulated_normalized_value() >= 0.5,
-        ))
+        // We'll add the `:checked` pseudoclass when the button is pressed. This uses the modulated
+        // normalised value — there's no convenient way to display both modulated and unmodulated
+        // values for a button.
+        .checked(modulated_signal.map(|v| *v >= 0.5))
     }
 
-    /// Set the parameter's normalized value to either 0.0 or 1.0 depending on its current value.
+    /// Set the parameter's normalised value to either 0.0 or 1.0 depending on its current value.
     fn toggle_value(&self, cx: &mut EventContext) {
         let current_value = self.param_base.unmodulated_normalized_value();
         let new_value = if current_value >= 0.5 { 0.0 } else { 1.0 };
@@ -121,21 +120,20 @@ impl View for ParamButton {
 
 /// Extension methods for [`ParamButton`] handles.
 pub trait ParamButtonExt {
-    /// Don't respond to scroll wheel events. Useful when this button is used as part of a scrolling
-    /// view.
+    /// Don't respond to scroll wheel events. Useful when this button is used as part of a
+    /// scrolling view.
     fn disable_scroll_wheel(self) -> Self;
 
-    /// Change the colors scheme for a bypass button. This simply adds the `bypass` class.
+    /// Change the colour scheme for a bypass button. Adds the `bypass` CSS class.
     fn for_bypass(self) -> Self;
 
-    /// Change the label used for the button. If this is not set, then the parameter's name will be
-    /// used.
+    /// Change the label used for the button. If this is not set, the parameter's name is used.
     fn with_label(self, value: impl Into<String>) -> Self;
 }
 
 impl ParamButtonExt for Handle<'_, ParamButton> {
     fn disable_scroll_wheel(self) -> Self {
-        self.modify(|param_slider: &mut ParamButton| param_slider.use_scroll_wheel = false)
+        self.modify(|param_button: &mut ParamButton| param_button.use_scroll_wheel = false)
     }
 
     fn for_bypass(self) -> Self {
@@ -144,7 +142,7 @@ impl ParamButtonExt for Handle<'_, ParamButton> {
 
     fn with_label(self, value: impl Into<String>) -> Self {
         self.modify(|param_button: &mut ParamButton| {
-            param_button.label_override = Some(value.into())
+            param_button.label_override.set(Some(value.into()));
         })
     }
 }

--- a/src/widgets/param_registry.rs
+++ b/src/widgets/param_registry.rs
@@ -1,0 +1,118 @@
+//! Bridge between nih-plug's pull-based [`Param`] model and vizia's push-based
+//! [`SyncSignal`] reactive graph.
+//!
+//! nih-plug exposes parameters through [`ParamPtr`] — stable opaque handles
+//! whose current values are read on demand via unsafe accessors. vizia's new
+//! signal-based binding system (vizia#619) requires observable values to be
+//! wrapped in [`SyncSignal`] so the reactive graph can track dependencies and
+//! push updates to subscribers.
+//!
+//! [`ParamRegistry`] owns one [`SyncSignal<f32>`] per (ParamPtr, axis) pair
+//! (axes: `Modulated`, `Unmodulated`). Widgets call
+//! [`ParamRegistry::normalized_signal`] on construction to get a signal for
+//! the param value they care about; the registry lazily creates signals on
+//! first access and reuses them on subsequent accesses.
+//!
+//! The editor side is responsible for flushing current values from
+//! [`ParamPtr`]s into the registry's signals whenever nih-plug reports a
+//! parameter change (typically via
+//! [`Editor::parameter_values_changed`][nih_plug::prelude::Editor::parameter_values_changed]).
+//! See [`ParamRegistry::flush_all`].
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use nih_plug::prelude::ParamPtr;
+use vizia::prelude::*;
+
+/// Which value of a parameter a signal tracks. nih-plug distinguishes
+/// between the raw user/host-set value (*unmodulated*) and the value after
+/// any monophonic modulation has been applied (*modulated*). Most widgets
+/// want modulated — it's what the user sees driving the audio — but some
+/// (e.g. a slider that visualises both) want both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ParamAxis {
+    /// `ParamPtr::modulated_normalized_value()`.
+    Modulated,
+    /// `ParamPtr::unmodulated_normalized_value()`.
+    Unmodulated,
+}
+
+/// Model that holds one [`SyncSignal<f32>`] per (ParamPtr, axis) pair, lazily
+/// created on first widget access.
+///
+/// Installed on the editor root by [`ViziaEditor::spawn`][super::super::editor::ViziaEditor::spawn]
+/// so widgets can reach it via [`Context::data`].
+pub struct ParamRegistry {
+    /// Lazily populated map of (`ParamPtr`, axis) → signal. The mutex is
+    /// only contended during widget construction and the editor's
+    /// `parameter_values_changed` flush, neither of which is hot.
+    signals: Mutex<HashMap<(ParamPtr, ParamAxis), SyncSignal<f32>>>,
+}
+
+impl ParamRegistry {
+    /// Creates an empty registry. Call on editor spawn and
+    /// [`Model::build`](vizia::prelude::Model::build) into the root context.
+    pub fn new() -> Self {
+        Self { signals: Mutex::new(HashMap::new()) }
+    }
+
+    /// Returns the signal tracking `param_ptr`'s value on the given `axis`,
+    /// creating it (initialised from the current unsafe `ParamPtr` value) if
+    /// it does not yet exist.
+    pub fn signal(&self, param_ptr: ParamPtr, axis: ParamAxis) -> SyncSignal<f32> {
+        let mut signals = self
+            .signals
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        *signals.entry((param_ptr, axis)).or_insert_with(|| {
+            let initial = unsafe {
+                match axis {
+                    ParamAxis::Modulated => param_ptr.modulated_normalized_value(),
+                    ParamAxis::Unmodulated => param_ptr.unmodulated_normalized_value(),
+                }
+            };
+            SyncSignal::new(initial)
+        })
+    }
+
+    /// Shorthand for the common case: the modulated normalised value.
+    pub fn modulated(&self, param_ptr: ParamPtr) -> SyncSignal<f32> {
+        self.signal(param_ptr, ParamAxis::Modulated)
+    }
+
+    /// Shorthand for the unmodulated (user/host-set) value.
+    pub fn unmodulated(&self, param_ptr: ParamPtr) -> SyncSignal<f32> {
+        self.signal(param_ptr, ParamAxis::Unmodulated)
+    }
+
+    /// Re-read every registered parameter via unsafe `ParamPtr` and write the
+    /// current value into its signal. Intended to be called from the editor's
+    /// `parameter_values_changed` hook; the reactive graph will then notify
+    /// any bound widgets.
+    pub fn flush_all(&self) {
+        let signals = self
+            .signals
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        for ((param_ptr, axis), signal) in signals.iter() {
+            let current = unsafe {
+                match axis {
+                    ParamAxis::Modulated => param_ptr.modulated_normalized_value(),
+                    ParamAxis::Unmodulated => param_ptr.unmodulated_normalized_value(),
+                }
+            };
+            signal.set_if_changed(current);
+        }
+    }
+}
+
+impl Default for ParamRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Model for ParamRegistry {}

--- a/src/widgets/param_registry.rs
+++ b/src/widgets/param_registry.rs
@@ -1,35 +1,37 @@
 //! Bridge between nih-plug's pull-based [`Param`] model and vizia's push-based
 //! [`SyncSignal`] reactive graph.
 //!
-//! nih-plug exposes parameters through [`ParamPtr`] — stable opaque handles
-//! whose current values are read on demand via unsafe accessors. vizia's new
-//! signal-based binding system (vizia#619) requires observable values to be
-//! wrapped in [`SyncSignal`] so the reactive graph can track dependencies and
-//! push updates to subscribers.
+//! nih-plug exposes parameters through [`ParamPtr`] — stable opaque handles whose current
+//! values are read on demand via unsafe accessors. vizia's new signal-based binding system
+//! (vizia#619) requires observable values to be wrapped in [`SyncSignal`] so the reactive
+//! graph can track dependencies and push updates to subscribers.
 //!
-//! [`ParamRegistry`] owns one [`SyncSignal<f32>`] per (ParamPtr, axis) pair
-//! (axes: `Modulated`, `Unmodulated`). Widgets call
-//! [`ParamRegistry::normalized_signal`] on construction to get a signal for
-//! the param value they care about; the registry lazily creates signals on
-//! first access and reuses them on subsequent accesses.
+//! [`ParamRegistry`] owns one [`SyncSignal<f32>`] per `(ParamPtr, axis)` pair (axes:
+//! `Modulated`, `Unmodulated`). Widgets call
+//! [`ParamRegistry::modulated`] / [`ParamRegistry::unmodulated`] on construction to obtain a
+//! signal for the param value they care about; the registry lazily creates signals on first
+//! access and reuses them on subsequent accesses.
 //!
-//! The editor side is responsible for flushing current values from
-//! [`ParamPtr`]s into the registry's signals whenever nih-plug reports a
-//! parameter change (typically via
-//! [`Editor::parameter_values_changed`][nih_plug::prelude::Editor::parameter_values_changed]).
+//! The editor side is responsible for flushing current values from [`ParamPtr`]s into the
+//! registry's signals whenever nih-plug reports a parameter change (via
+//! [`Editor::parameter_value_changed`](nih_plug::prelude::Editor::parameter_value_changed) /
+//! [`Editor::parameter_values_changed`](nih_plug::prelude::Editor::parameter_values_changed)).
 //! See [`ParamRegistry::flush_all`].
+//!
+//! The type is cheaply `Clone` (it's an `Arc` internally), so the editor can keep its own
+//! handle for flushing while also installing a clone as a vizia [`Model`] for widget lookup.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::Arc;
 
 use nih_plug::prelude::ParamPtr;
+use parking_lot::Mutex;
 use vizia::prelude::*;
 
-/// Which value of a parameter a signal tracks. nih-plug distinguishes
-/// between the raw user/host-set value (*unmodulated*) and the value after
-/// any monophonic modulation has been applied (*modulated*). Most widgets
-/// want modulated — it's what the user sees driving the audio — but some
-/// (e.g. a slider that visualises both) want both.
+/// Which value of a parameter a signal tracks. nih-plug distinguishes between the raw
+/// user/host-set value (*unmodulated*) and the value after any monophonic modulation has been
+/// applied (*modulated*). Most widgets want modulated — it's what the user sees driving the
+/// audio — but some (e.g. a slider that visualises both) want both.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ParamAxis {
     /// `ParamPtr::modulated_normalized_value()`.
@@ -38,35 +40,41 @@ pub enum ParamAxis {
     Unmodulated,
 }
 
-/// Model that holds one [`SyncSignal<f32>`] per (ParamPtr, axis) pair, lazily
-/// created on first widget access.
-///
-/// Installed on the editor root by [`ViziaEditor::spawn`][super::super::editor::ViziaEditor::spawn]
-/// so widgets can reach it via [`Context::data`].
+/// Shared, `Clone`-able handle to a set of param-tracking [`SyncSignal`]s. The same value
+/// backs both the editor's flush path and the widget-facing lookup path — cloning a
+/// `ParamRegistry` returns another handle to the same underlying signal map.
+#[derive(Clone)]
 pub struct ParamRegistry {
-    /// Lazily populated map of (`ParamPtr`, axis) → signal. The mutex is
-    /// only contended during widget construction and the editor's
-    /// `parameter_values_changed` flush, neither of which is hot.
+    inner: Arc<ParamRegistryInner>,
+}
+
+struct ParamRegistryInner {
+    /// Lazily populated map of `(ParamPtr, axis)` → signal.
+    ///
+    /// Locked briefly by widgets on construction (UI thread) and by the editor on every
+    /// parameter-change callback ([`flush_all`](ParamRegistry::flush_all), which nih-plug
+    /// calls on the host / audio thread). Using `parking_lot::Mutex` rather than
+    /// `std::sync::Mutex` keeps the audio-thread side light — no poisoning checks, no
+    /// priority-inversion hazard if the UI thread is holding the lock during widget build.
     signals: Mutex<HashMap<(ParamPtr, ParamAxis), SyncSignal<f32>>>,
 }
 
 impl ParamRegistry {
-    /// Creates an empty registry. Call on editor spawn and
-    /// [`Model::build`](vizia::prelude::Model::build) into the root context.
+    /// Creates an empty registry.
     pub fn new() -> Self {
-        Self { signals: Mutex::new(HashMap::new()) }
+        Self {
+            inner: Arc::new(ParamRegistryInner { signals: Mutex::new(HashMap::new()) }),
+        }
     }
 
-    /// Returns the signal tracking `param_ptr`'s value on the given `axis`,
-    /// creating it (initialised from the current unsafe `ParamPtr` value) if
-    /// it does not yet exist.
+    /// Returns the signal tracking `param_ptr`'s value on the given `axis`, creating it
+    /// (initialised from the current unsafe `ParamPtr` value) if it does not yet exist.
     pub fn signal(&self, param_ptr: ParamPtr, axis: ParamAxis) -> SyncSignal<f32> {
-        let mut signals = self
-            .signals
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let mut signals = self.inner.signals.lock();
 
         *signals.entry((param_ptr, axis)).or_insert_with(|| {
+            // SAFETY: `param_ptr` was resolved from a valid `&impl Param` at widget
+            // construction; it stays valid for the plugin's lifetime.
             let initial = unsafe {
                 match axis {
                     ParamAxis::Modulated => param_ptr.modulated_normalized_value(),
@@ -87,17 +95,14 @@ impl ParamRegistry {
         self.signal(param_ptr, ParamAxis::Unmodulated)
     }
 
-    /// Re-read every registered parameter via unsafe `ParamPtr` and write the
-    /// current value into its signal. Intended to be called from the editor's
-    /// `parameter_values_changed` hook; the reactive graph will then notify
-    /// any bound widgets.
+    /// Re-read every registered parameter via unsafe `ParamPtr` and write the current value
+    /// into its signal. Intended to be called from the editor's `parameter_value_changed` /
+    /// `parameter_values_changed` hooks; the reactive graph then notifies any bound widgets.
     pub fn flush_all(&self) {
-        let signals = self
-            .signals
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let signals = self.inner.signals.lock();
 
         for ((param_ptr, axis), signal) in signals.iter() {
+            // SAFETY: see `signal()`.
             let current = unsafe {
                 match axis {
                     ParamAxis::Modulated => param_ptr.modulated_normalized_value(),

--- a/src/widgets/param_slider.rs
+++ b/src/widgets/param_slider.rs
@@ -259,7 +259,7 @@ impl ParamSlider {
                         let preview = param_base
                             .normalized_value_to_string(normalized_value, true);
 
-                        Label::new(cx, &preview)
+                        Label::new(cx, preview)
                             .class("value")
                             .class("value--multiple")
                             .alignment(Alignment::Center)
@@ -276,7 +276,7 @@ impl ParamSlider {
                     // If the label override is set, use it. Otherwise show the parameter's
                     // current display value (before modulation).
                     match label_override.get() {
-                        Some(label) => Label::new(cx, &label),
+                        Some(label) => Label::new(cx, label),
                         None => Label::new(cx, display_value),
                     }
                     .class("value")

--- a/src/widgets/param_slider.rs
+++ b/src/widgets/param_slider.rs
@@ -1,6 +1,6 @@
 //! A slider that integrates with NIH-plug's [`Param`] types.
 
-use nih_plug::prelude::Param;
+use nih_plug::prelude::{Param, ParamPtr};
 use vizia::prelude::*;
 
 use super::param_base::ParamWidgetBase;
@@ -11,52 +11,52 @@ use super::util::{self, ModifiersExt};
 const GRANULAR_DRAG_MULTIPLIER: f32 = 0.1;
 
 /// A slider that integrates with NIH-plug's [`Param`] types. Use the
-/// [`set_style()`][ParamSliderExt::set_style()] method to change how the value gets displayed.
-#[derive(Lens)]
+/// [`set_style()`][ParamSliderExt::set_style] method to change how the value is displayed.
+///
+/// Under the signal-based API these three fields are held as [`SyncSignal`]s so the build
+/// closure (which needs to be `'static`) can subscribe to them without borrowing the slider.
 pub struct ParamSlider {
     param_base: ParamWidgetBase,
 
-    /// Will be set to `true` when the field gets Alt+Click'ed which will replace the label with a
-    /// text box.
-    text_input_active: bool,
-    /// Will be set to `true` if we're dragging the parameter. Resetting the parameter or entering a
+    /// Set to `true` when the field gets Alt+Click'ed — replaces the label with a text box.
+    text_input_active: SyncSignal<bool>,
+    /// What style to use for the slider.
+    style: SyncSignal<ParamSliderStyle>,
+    /// A specific label to use instead of displaying the parameter's value.
+    label_override: SyncSignal<Option<String>>,
+
+    /// Set to `true` while we're dragging the parameter. Resetting the parameter or entering a
     /// text value should not initiate a drag.
     drag_active: bool,
-    /// We keep track of the start coordinate and normalized value when holding down Shift while
-    /// dragging for higher precision dragging. This is a `None` value when granular dragging is not
-    /// active.
+    /// Start coordinate and normalized value when holding down Shift while dragging for higher
+    /// precision dragging. `None` when granular dragging is not active.
     granular_drag_status: Option<GranularDragStatus>,
 
     // These fields are set through modifiers:
     /// Whether or not to listen to scroll events for changing the parameter's value in steps.
     use_scroll_wheel: bool,
-    /// The number of (fractional) scrolled lines that have not yet been turned into parameter
-    /// change events. This is needed to support trackpads with smooth scrolling.
+    /// Fractional scrolled lines not yet turned into parameter change events. Needed for
+    /// trackpads with smooth scrolling.
     scrolled_lines: f32,
-    /// What style to use for the slider.
-    style: ParamSliderStyle,
-    /// A specific label to use instead of displaying the parameter's value.
-    label_override: Option<String>,
 }
 
 /// How the [`ParamSlider`] should display its values. Set this using
-/// [`ParamSliderExt::set_style()`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Data)]
+/// [`ParamSliderExt::set_style`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParamSliderStyle {
-    /// Visualize the offset from the default value for continuous parameters with a default value
-    /// at around half of its range, fill the bar from the left for discrete parameters and
-    /// continuous parameters without centered default values.
+    /// Visualize the offset from the default value for continuous parameters with a default
+    /// value around the middle of the range, fill from the left for discrete parameters and
+    /// continuous parameters without centered defaults.
     Centered,
     /// Always fill the bar starting from the left.
     FromLeft,
-    /// Show the current step instead of filling a portion of the bar, useful for discrete
+    /// Show the current step instead of filling a portion of the bar. Useful for discrete
     /// parameters. Set `even` to `true` to distribute the ticks evenly instead of following the
-    /// parameter's distribution. This can be desireable because discrete parameters have smaller
-    /// ranges near the edges (they'll span only half the range, which can make the display look
-    /// odd).
+    /// parameter's distribution — discrete parameters span only half the range near the edges,
+    /// which can make the display look odd.
     CurrentStep { even: bool },
-    /// The same as `CurrentStep`, but overlay the labels over the steps instead of showing the
-    /// active value. Only useful for discrete parameters with two, maybe three possible values.
+    /// The same as `CurrentStep`, but overlays the labels over the steps instead of showing the
+    /// active value. Only useful for discrete parameters with two or maybe three possible values.
     CurrentStepLabeled { even: bool },
 }
 
@@ -67,128 +67,119 @@ enum ParamSliderEvent {
     TextInput(String),
 }
 
-// TODO: Vizia's lens derive macro requires this to be marked as pub
 #[derive(Debug, Clone, Copy)]
-pub struct GranularDragStatus {
+struct GranularDragStatus {
     /// The mouse's X-coordinate when the granular drag was started.
-    pub starting_x_coordinate: f32,
+    starting_x_coordinate: f32,
     /// The normalized value when the granular drag was started.
-    pub starting_value: f32,
+    starting_value: f32,
 }
 
 impl ParamSlider {
-    /// Creates a new [`ParamSlider`] for the given parameter. To accommodate VIZIA's mapping system,
-    /// you'll need to provide a lens containing your `Params` implementation object (check out how
-    /// the `Data` struct is used in `gain_gui_vizia`) and a projection function that maps the
-    /// `Params` object to the parameter you want to display a widget for. Parameter changes are
-    /// handled by emitting [`ParamEvent`][super::ParamEvent]s which are automatically handled by
-    /// the VIZIA wrapper.
+    /// Creates a new [`ParamSlider`] for the given parameter. Pass a reference to the
+    /// parameter directly — e.g. `ParamSlider::new(cx, &params.gain)`.
+    ///
+    /// Parameter changes are handled by emitting [`ParamEvent`](super::ParamEvent)s, which
+    /// are automatically processed by the vizia-plug wrapper.
+    ///
+    /// The `'p: 'c` bound reads as "the parameter must outlive the context borrow": the
+    /// builder closure captured into `cx` borrows `param` to resolve static metadata, so the
+    /// parameter's storage (normally inside the plugin's `Arc<Params>`) has to stay alive at
+    /// least as long as the widget is being built. In practice this is always true — `Params`
+    /// lives for the plugin's lifetime — the bound just lets the borrow checker prove it.
     ///
     /// See [`ParamSliderExt`] for additional options.
-    pub fn new<L, Params, P, FMap>(
-        cx: &mut Context,
-        params: L,
-        params_to_param: FMap,
-    ) -> Handle<Self>
+    pub fn new<'c, 'p, P>(cx: &'c mut Context, param: &'p P) -> Handle<'c, Self>
     where
-        L: Lens<Target = Params> + Clone,
-        Params: 'static,
+        'p: 'c,
         P: Param + 'static,
-        FMap: Fn(&Params) -> &P + Copy + 'static,
     {
-        // We'll visualize the difference between the current value and the default value if the
-        // default value lies somewhere in the middle and the parameter is continuous. Otherwise
-        // this approach looks a bit jarring.
-        Self {
-            param_base: ParamWidgetBase::new(cx, params, params_to_param),
+        let param_base = ParamWidgetBase::new(cx, param);
+        let text_input_active = SyncSignal::new(false);
+        let style = SyncSignal::new(ParamSliderStyle::Centered);
+        let label_override: SyncSignal<Option<String>> = SyncSignal::new(None);
 
-            text_input_active: false,
+        let unmodulated_signal = param_base.unmodulated_signal(cx);
+        let modulated_signal = param_base.modulated_signal(cx);
+
+        Self {
+            param_base,
+            text_input_active,
+            style,
+            label_override,
             drag_active: false,
             granular_drag_status: None,
-
             use_scroll_wheel: true,
             scrolled_lines: 0.0,
-            style: ParamSliderStyle::Centered,
-            label_override: None,
         }
         .build(
             cx,
-            ParamWidgetBase::build_view(params, params_to_param, move |cx, param_data| {
-                Binding::new(cx, ParamSlider::style, move |cx, style| {
-                    let style = style.get(cx);
+            ParamWidgetBase::build_view(param, move |cx, _param_data| {
+                // Bind on the style signal — style only changes when `.set_style()` is called,
+                // so this rebuilds the slider contents rarely in practice.
+                Binding::new(cx, style, move |cx| {
+                    let style = style.get();
+                    let param_ptr = param_base.param_ptr();
 
-                    // Can't use `.to_string()` here as that would include the modulation.
-                    let unmodulated_normalized_value_lens =
-                        param_data.make_lens(|param| param.unmodulated_normalized_value());
-                    let display_value_lens = param_data.make_lens(|param| {
-                        param.normalized_value_to_string(param.unmodulated_normalized_value(), true)
+                    // Derived display string. Single reactive input: the unmodulated value.
+                    // SAFETY for the `ParamPtr` read: resolved from a valid `&impl Param` at
+                    // widget construction; the pointer stays valid for the plugin's lifetime.
+                    let display_value: Memo<String> = Memo::new(move |_| {
+                        let current = unmodulated_signal.get();
+                        unsafe { param_ptr.normalized_value_to_string(current, true) }
                     });
 
-                    // The resulting tuple `(start_t, delta)` corresponds to the start and the
-                    // signed width of the bar. `start_t` is in `[0, 1]`, and `delta` is in
-                    // `[-1, 1]`.
-                    let fill_start_delta_lens =
-                        unmodulated_normalized_value_lens.map(move |current_value| {
-                            Self::compute_fill_start_delta(
-                                style,
-                                param_data.param(),
-                                *current_value,
-                            )
-                        });
-
-                    // If the parameter is being modulated by the host (this only works for CLAP
-                    // plugins with hosts that support this), then this is the difference
-                    // between the 'true' value and the current value after modulation has been
-                    // applied. This follows the same format as `fill_start_delta_lens`.
-                    let modulation_start_delta_lens = param_data.make_lens(move |param| {
-                        Self::compute_modulation_fill_start_delta(style, param)
+                    // `(start_t, delta)` for the filled portion of the bar. `start_t ∈ [0, 1]`,
+                    // `delta ∈ [-1, 1]`. Reactive input: the unmodulated value. The helper also
+                    // reads static parameter metadata (default value, step count, step
+                    // distribution) via the `ParamPtr`; those are invariant for the plugin's
+                    // lifetime so they don't need to be tracked as reactive dependencies.
+                    let fill_start_delta: Memo<(f32, f32)> = Memo::new(move |_| {
+                        let current = unmodulated_signal.get();
+                        Self::compute_fill_start_delta(style, param_ptr, current)
                     });
 
-                    // This is used to draw labels for `CurrentStepLabeled`
-                    let make_preview_value_lens = move |normalized_value| {
-                        param_data.make_lens(move |param| {
-                            param.normalized_value_to_string(normalized_value, true)
-                        })
-                    };
+                    // Modulation offset bar. Reactive inputs: both unmodulated and modulated
+                    // values — if either moves, the delta must be recomputed. Reading both
+                    // via `.get()` inside the memo closure subscribes to both signals.
+                    let modulation_start_delta: Memo<(f32, f32)> = Memo::new(move |_| {
+                        let unmod = unmodulated_signal.get();
+                        let modulated = modulated_signal.get();
+                        Self::compute_modulation_fill_start_delta(style, unmod, modulated)
+                    });
 
-                    // Only draw the text input widget when it gets focussed. Otherwise, overlay the
-                    // label with the slider. Creating the textbox based on
-                    // `ParamSliderInternal::text_input_active` lets us focus the textbox when it gets
-                    // created.
-                    Binding::new(
-                        cx,
-                        ParamSlider::text_input_active,
-                        move |cx, text_input_active| {
-                            if text_input_active.get(cx) {
-                                Self::text_input_view(cx, display_value_lens);
-                            } else {
-                                ZStack::new(cx, |cx| {
-                                    Self::slider_fill_view(
-                                        cx,
-                                        fill_start_delta_lens,
-                                        modulation_start_delta_lens,
-                                    );
-                                    Self::slider_label_view(
-                                        cx,
-                                        param_data.param(),
-                                        style,
-                                        display_value_lens,
-                                        make_preview_value_lens,
-                                        ParamSlider::label_override,
-                                    );
-                                })
-                                .hoverable(false);
-                            }
-                        },
-                    );
+                    // Only draw the text input when it's active. Otherwise overlay the label
+                    // on the slider fill. Creating the textbox based on `text_input_active`
+                    // lets us focus it when it gets created.
+                    Binding::new(cx, text_input_active, move |cx| {
+                        if text_input_active.get() {
+                            Self::text_input_view(cx, display_value);
+                        } else {
+                            ZStack::new(cx, |cx| {
+                                Self::slider_fill_view(
+                                    cx,
+                                    fill_start_delta,
+                                    modulation_start_delta,
+                                );
+                                Self::slider_label_view(
+                                    cx,
+                                    param_base,
+                                    style,
+                                    display_value,
+                                    label_override,
+                                );
+                            })
+                            .hoverable(false);
+                        }
+                    });
                 });
             }),
         )
     }
 
     /// Create a text input that's shown in place of the slider.
-    fn text_input_view(cx: &mut Context, display_value_lens: impl Lens<Target = String>) {
-        Textbox::new(cx, display_value_lens)
+    fn text_input_view(cx: &mut Context, display_value: Memo<String>) {
+        Textbox::new(cx, display_value)
             .class("value-entry")
             .on_submit(|cx, string, success| {
                 if success {
@@ -204,7 +195,6 @@ impl ParamSlider {
                 cx.emit(TextEvent::StartEdit);
                 cx.emit(TextEvent::SelectAll);
             })
-            // `.child_space(Stretch(1.0))` no longer works
             .class("align_center")
             .alignment(Alignment::Left)
             .height(Stretch(1.0))
@@ -214,67 +204,62 @@ impl ParamSlider {
     /// Create the fill part of the slider.
     fn slider_fill_view(
         cx: &mut Context,
-        fill_start_delta_lens: impl Lens<Target = (f32, f32)>,
-        modulation_start_delta_lens: impl Lens<Target = (f32, f32)>,
+        fill_start_delta: Memo<(f32, f32)>,
+        modulation_start_delta: Memo<(f32, f32)>,
     ) {
-        // The filled bar portion. This can be visualized in a couple different ways depending on
-        // the current style property. See [`ParamSliderStyle`].
+        // The filled bar portion. Visualized differently depending on the current style — see
+        // [`ParamSliderStyle`].
         Element::new(cx)
             .class("fill")
             .height(Stretch(1.0))
-            .left(fill_start_delta_lens.map(|(start_t, _)| Percentage(start_t * 100.0)))
-            .width(fill_start_delta_lens.map(|(_, delta)| Percentage(delta * 100.0)))
-            // Hovering is handled on the param slider as a whole, this
-            // should not affect that
+            .left(fill_start_delta.map(|(start_t, _)| Percentage(*start_t * 100.0)))
+            .width(fill_start_delta.map(|(_, delta)| Percentage(*delta * 100.0)))
+            // Hovering is handled on the param slider as a whole.
             .hoverable(false);
 
-        // If the parameter is being modulated, then we'll display another
-        // filled bar showing the current modulation delta
-        // VIZIA's bindings make this a bit, uh, difficult to read
+        // If the parameter is being modulated, another filled bar shows the modulation delta.
         Element::new(cx)
             .class("fill")
             .class("fill--modulation")
             .height(Stretch(1.0))
-            .visibility(modulation_start_delta_lens.map(|(_, delta)| *delta != 0.0))
-            // Widths cannot be negative, so we need to compensate the start
-            // position if the width does happen to be negative
-            .width(modulation_start_delta_lens.map(|(_, delta)| Percentage(delta.abs() * 100.0)))
-            .left(modulation_start_delta_lens.map(|(start_t, delta)| {
+            .visibility(modulation_start_delta.map(|(_, delta)| *delta != 0.0))
+            // Widths can't be negative, so compensate the start position if the width is
+            // negative.
+            .width(modulation_start_delta.map(|(_, delta)| Percentage(delta.abs() * 100.0)))
+            .left(modulation_start_delta.map(|(start_t, delta)| {
                 if *delta < 0.0 {
-                    Percentage((start_t + delta) * 100.0)
+                    Percentage((*start_t + *delta) * 100.0)
                 } else {
-                    Percentage(start_t * 100.0)
+                    Percentage(*start_t * 100.0)
                 }
             }))
             .hoverable(false);
     }
 
     /// Create the text part of the slider. Shown on top of the fill using a `ZStack`.
-    fn slider_label_view<P: Param, L: Lens<Target = String>>(
+    fn slider_label_view(
         cx: &mut Context,
-        param: &P,
+        param_base: ParamWidgetBase,
         style: ParamSliderStyle,
-        display_value_lens: impl Lens<Target = String>,
-        make_preview_value_lens: impl Fn(f32) -> L,
-        label_override_lens: impl Lens<Target = Option<String>>,
+        display_value: Memo<String>,
+        label_override: SyncSignal<Option<String>>,
     ) {
-        let step_count = param.step_count();
+        let step_count = param_base.step_count();
 
-        // Either display the current value, or display all values over the
-        // parameter's steps
-        // TODO: Do the same thing as in the iced widget where we draw the
-        //       text overlapping the fill area slightly differently. We can
-        //       set the cip region directly in vizia.
+        // Either display the current value, or display all values over the parameter's steps.
         match (style, step_count) {
             (ParamSliderStyle::CurrentStepLabeled { .. }, Some(step_count)) => {
                 HStack::new(cx, |cx| {
-                    // There are step_count + 1 possible values for a
-                    // discrete parameter
+                    // step_count + 1 possible values for a discrete parameter. Each preview
+                    // label is a static string derived from the parameter's own formatter at
+                    // its step position — it never changes at runtime, so we format it once
+                    // here rather than threading it through the reactive graph.
                     for value in 0..step_count + 1 {
                         let normalized_value = value as f32 / step_count as f32;
-                        let preview_lens = make_preview_value_lens(normalized_value);
+                        let preview = param_base
+                            .normalized_value_to_string(normalized_value, true);
 
-                        Label::new(cx, preview_lens)
+                        Label::new(cx, &preview)
                             .class("value")
                             .class("value--multiple")
                             .alignment(Alignment::Center)
@@ -287,12 +272,12 @@ impl ParamSlider {
                 .hoverable(false);
             }
             _ => {
-                Binding::new(cx, label_override_lens, move |cx, label_override_lens| {
-                    // If the label override is set then we'll use that. If not, the parameter's
-                    // current display value (before modulation) is used.
-                    match label_override_lens.get(cx) {
-                        Some(label_override) => Label::new(cx, &label_override),
-                        None => Label::new(cx, display_value_lens),
+                Binding::new(cx, label_override, move |cx| {
+                    // If the label override is set, use it. Otherwise show the parameter's
+                    // current display value (before modulation).
+                    match label_override.get() {
+                        Some(label) => Label::new(cx, &label),
+                        None => Label::new(cx, display_value),
                     }
                     .class("value")
                     .class("value--single")
@@ -301,20 +286,22 @@ impl ParamSlider {
                     .hoverable(false);
                 });
             }
-        };
+        }
     }
 
-    /// Calculate the start position and width of the slider's fill region based on the selected
-    /// style, the parameter's current value, and the parameter's step sizes. The resulting tuple
-    /// `(start_t, delta)` corresponds to the start and the signed width of the bar. `start_t` is in
-    /// `[0, 1]`, and `delta` is in `[-1, 1]`.
-    fn compute_fill_start_delta<P: Param>(
+    /// Start position and width of the slider's fill region based on the selected style, the
+    /// parameter's current value, and the parameter's step sizes.
+    ///
+    /// Returns `(start_t, delta)` where `start_t ∈ [0, 1]` and `delta ∈ [-1, 1]`.
+    fn compute_fill_start_delta(
         style: ParamSliderStyle,
-        param: &P,
+        param_ptr: ParamPtr,
         current_value: f32,
     ) -> (f32, f32) {
-        let default_value = param.default_normalized_value();
-        let step_count = param.step_count();
+        // SAFETY: `param_ptr` was resolved from a valid `&impl Param` at widget construction;
+        // it stays valid for the plugin's lifetime.
+        let default_value = unsafe { param_ptr.default_normalized_value() };
+        let step_count = unsafe { param_ptr.step_count() };
         let draw_fill_from_default = matches!(style, ParamSliderStyle::Centered)
             && step_count.is_none()
             && (0.45..=0.55).contains(&default_value);
@@ -323,8 +310,8 @@ impl ParamSlider {
             ParamSliderStyle::Centered if draw_fill_from_default => {
                 let delta = (default_value - current_value).abs();
 
-                // Don't draw the filled portion at all if it could have been a
-                // rounding error since those slivers just look weird
+                // Don't draw the filled portion at all if it could be a rounding error — those
+                // slivers look weird.
                 (
                     default_value.min(current_value),
                     if delta >= 1e-3 { delta } else { 0.0 },
@@ -335,8 +322,7 @@ impl ParamSlider {
             | ParamSliderStyle::CurrentStepLabeled { even: true }
                 if step_count.is_some() =>
             {
-                // Assume the normalized value is distributed evenly
-                // across the range.
+                // Assume the normalized value is distributed evenly across the range.
                 let step_count = step_count.unwrap() as f32;
                 let discrete_values = step_count + 1.0;
                 let previous_step = (current_value * step_count) / discrete_values;
@@ -344,8 +330,9 @@ impl ParamSlider {
                 (previous_step, discrete_values.recip())
             }
             ParamSliderStyle::CurrentStep { .. } | ParamSliderStyle::CurrentStepLabeled { .. } => {
-                let previous_step = param.previous_normalized_step(current_value, false);
-                let next_step = param.next_normalized_step(current_value, false);
+                let previous_step =
+                    unsafe { param_ptr.previous_normalized_step(current_value, false) };
+                let next_step = unsafe { param_ptr.next_normalized_step(current_value, false) };
 
                 (
                     (previous_step + current_value) / 2.0,
@@ -355,51 +342,46 @@ impl ParamSlider {
         }
     }
 
-    /// The same as `compute_fill_start_delta`, but just showing the modulation offset.
-    fn compute_modulation_fill_start_delta<P: Param>(
+    /// Same as [`compute_fill_start_delta`](Self::compute_fill_start_delta), but showing only
+    /// the modulation offset. Pure function of its inputs — the caller is responsible for
+    /// feeding fresh `unmodulated_normalized` and `modulated_normalized` values, so the
+    /// reactive graph can track both as dependencies.
+    fn compute_modulation_fill_start_delta(
         style: ParamSliderStyle,
-        param: &P,
+        unmodulated_normalized: f32,
+        modulated_normalized: f32,
     ) -> (f32, f32) {
         match style {
-            // Don't show modulation for stepped parameters since it wouldn't
-            // make a lot of sense visually
+            // Don't show modulation for stepped parameters — visually meaningless.
             ParamSliderStyle::CurrentStep { .. } | ParamSliderStyle::CurrentStepLabeled { .. } => {
                 (0.0, 0.0)
             }
-            ParamSliderStyle::Centered | ParamSliderStyle::FromLeft => {
-                let modulation_start = param.unmodulated_normalized_value();
-
-                (
-                    modulation_start,
-                    param.modulated_normalized_value() - modulation_start,
-                )
-            }
+            ParamSliderStyle::Centered | ParamSliderStyle::FromLeft => (
+                unmodulated_normalized,
+                modulated_normalized - unmodulated_normalized,
+            ),
         }
     }
 
     /// `self.param_base.set_normalized_value()`, but resulting from a mouse drag. When using the
-    /// 'even' stepped slider styles from [`ParamSliderStyle`] this will remap the normalized range
-    /// to match up with the fill value display. This still needs to be wrapped in a parameter
-    /// automation gesture.
+    /// 'even' stepped slider styles this remaps the normalized range to match the fill-value
+    /// display. Still needs to be wrapped in a parameter automation gesture.
     fn set_normalized_value_drag(&self, cx: &mut EventContext, normalized_value: f32) {
-        
-        let normalized_value = match (self.style, self.param_base.step_count()) {
+        let normalized_value = match (self.style.get(), self.param_base.step_count()) {
             (
                 ParamSliderStyle::CurrentStep { even: true }
                 | ParamSliderStyle::CurrentStepLabeled { even: true },
                 Some(step_count),
             ) => {
-                // We'll remap the value range to be the same as the displayed range, e.g. with each
-                // value occupying an equal area on the slider instead of the centers of those
-                // ranges being distributed over the entire `[0, 1]` range.
+                // Remap the value range to the displayed range (each value occupies an equal
+                // area on the slider instead of the centers of those ranges being distributed
+                // over the entire `[0, 1]` range).
                 let discrete_values = step_count as f32 + 1.0;
                 let rounded_value = ((normalized_value * discrete_values) - 0.5).round();
                 rounded_value / step_count as f32
             }
             _ => normalized_value,
         };
-
-        
 
         self.param_base.set_normalized_value(cx, normalized_value);
     }
@@ -413,54 +395,54 @@ impl View for ParamSlider {
     fn event(&mut self, cx: &mut EventContext, event: &mut Event) {
         event.map(|param_slider_event, meta| match param_slider_event {
             ParamSliderEvent::CancelTextInput => {
-                self.text_input_active = false;
+                self.text_input_active.set(false);
                 cx.set_active(false);
 
                 meta.consume();
             }
             ParamSliderEvent::TextInput(string) => {
-                if let Some(normalized_value) = self.param_base.string_to_normalized_value(string) {
+                if let Some(normalized_value) =
+                    self.param_base.string_to_normalized_value(string)
+                {
                     self.param_base.begin_set_parameter(cx);
                     self.param_base.set_normalized_value(cx, normalized_value);
                     self.param_base.end_set_parameter(cx);
                 }
 
-                self.text_input_active = false;
+                self.text_input_active.set(false);
 
                 meta.consume();
             }
         });
 
         event.map(|window_event, meta| match window_event {
-            // Vizia always captures the third mouse click as a triple click. Treating that triple
-            // click as a regular mouse button makes double click followed by another drag work as
-            // expected, instead of requiring a delay or an additional click. Double double click
-            // still won't work.
+            // Vizia always captures the third mouse click as a triple click. Treating triple
+            // click as a regular mouse button makes double-click-then-drag work as expected
+            // without requiring a delay or an additional click. Double double click still
+            // won't work.
             WindowEvent::MouseDown(MouseButton::Left)
             | WindowEvent::MouseTripleClick(MouseButton::Left) => {
                 if cx.modifiers().alt() {
-                    // ALt+Click brings up a text entry dialog
-                    self.text_input_active = true;
+                    // Alt+Click brings up a text entry dialog.
+                    self.text_input_active.set(true);
                     cx.set_active(true);
                 } else if cx.modifiers().command() {
-                    // Ctrl+Click, double click, and right clicks should reset the parameter instead
-                    // of initiating a drag operation
+                    // Ctrl+Click, double click, and right clicks reset the parameter.
                     self.param_base.begin_set_parameter(cx);
                     self.param_base
                         .set_normalized_value(cx, self.param_base.default_normalized_value());
                     self.param_base.end_set_parameter(cx);
-                } else if !self.text_input_active {
-                    // The `!self.text_input_active` check shouldn't be needed, but the textbox does
-                    // not consume the mouse down event. So clicking on the textbox to move the
-                    // cursor would also change the slider.
+                } else if !self.text_input_active.get() {
+                    // The `!text_input_active` check shouldn't be needed, but the textbox
+                    // doesn't consume the mouse-down event. Without this, clicking on the
+                    // textbox to move the cursor would also change the slider.
                     self.drag_active = true;
                     cx.capture();
-                    // NOTE: Otherwise we don't get key up events
+                    // Otherwise we don't get key-up events.
                     cx.focus();
                     cx.set_active(true);
 
-                    // When holding down shift while clicking on a parameter we want to granuarly
-                    // edit the parameter without jumping to a new value
+                    // Holding shift while clicking initiates granular editing without jumping.
                     self.param_base.begin_set_parameter(cx);
                     if cx.modifiers().shift() {
                         self.granular_drag_status = Some(GranularDragStatus {
@@ -482,8 +464,6 @@ impl View for ParamSlider {
             | WindowEvent::MouseDown(MouseButton::Right)
             | WindowEvent::MouseDoubleClick(MouseButton::Right)
             | WindowEvent::MouseTripleClick(MouseButton::Right) => {
-                // Ctrl+Click, double click, and right clicks should reset the parameter instead of
-                // initiating a drag operation
                 self.param_base.begin_set_parameter(cx);
                 self.param_base
                     .set_normalized_value(cx, self.param_base.default_normalized_value());
@@ -503,26 +483,24 @@ impl View for ParamSlider {
                 }
             }
             WindowEvent::MouseMove(x, _y) => {
-                
-                // if meta.target == cx.current() {
-                //     println!("{}", *x);
-                // }
                 if self.drag_active {
-                    // If shift is being held then the drag should be more granular instead of
-                    // absolute
+                    // If shift is held, dragging is granular rather than absolute.
                     if cx.modifiers().shift() {
                         let granular_drag_status =
-                            *self
-                                .granular_drag_status
-                                .get_or_insert_with(|| GranularDragStatus {
+                            *self.granular_drag_status.get_or_insert_with(|| {
+                                GranularDragStatus {
                                     starting_x_coordinate: *x,
-                                    starting_value: self.param_base.unmodulated_normalized_value(),
-                                });
+                                    starting_value: self
+                                        .param_base
+                                        .unmodulated_normalized_value(),
+                                }
+                            });
 
-                        // These positions should be compensated for the DPI scale so it remains
-                        // consistent
-                        let start_x =
-                            util::remap_current_entity_x_t(cx, granular_drag_status.starting_value);
+                        // Compensate for the DPI scale to keep the drag consistent.
+                        let start_x = util::remap_current_entity_x_t(
+                            cx,
+                            granular_drag_status.starting_value,
+                        );
                         let delta_x = ((*x - granular_drag_status.starting_x_coordinate)
                             * GRANULAR_DRAG_MULTIPLIER)
                             * cx.scale_factor();
@@ -533,9 +511,6 @@ impl View for ParamSlider {
                         );
                     } else {
                         self.granular_drag_status = None;
-
-                        
-
                         self.set_normalized_value_drag(
                             cx,
                             util::remap_current_entity_x_coordinate(cx, *x),
@@ -544,8 +519,7 @@ impl View for ParamSlider {
                 }
             }
             WindowEvent::KeyUp(_, Some(Key::Shift)) => {
-                // If this happens while dragging, snap back to reality uh I mean the current screen
-                // position
+                // If this happens mid-drag, snap back to the current screen position.
                 if self.drag_active && self.granular_drag_status.is_some() {
                     self.granular_drag_status = None;
                     self.param_base.set_normalized_value(
@@ -555,14 +529,13 @@ impl View for ParamSlider {
                 }
             }
             WindowEvent::MouseScroll(_scroll_x, scroll_y) if self.use_scroll_wheel => {
-                // With a regular scroll wheel `scroll_y` will only ever be -1 or 1, but with smooth
-                // scrolling trackpads being a thing `scroll_y` could be anything.
+                // A regular scroll wheel sends ±1; smooth-scrolling trackpads send anything.
                 self.scrolled_lines += scroll_y;
 
                 if self.scrolled_lines.abs() >= 1.0 {
                     let use_finer_steps = cx.modifiers().shift();
 
-                    // Scrolling while dragging needs to be taken into account here
+                    // Scrolling while dragging needs to be taken into account here.
                     if !self.drag_active {
                         self.param_base.begin_set_parameter(cx);
                     }
@@ -599,15 +572,14 @@ impl View for ParamSlider {
 
 /// Extension methods for [`ParamSlider`] handles.
 pub trait ParamSliderExt {
-    /// Don't respond to scroll wheel events. Useful when this slider is used as part of a scrolling
-    /// view.
+    /// Don't respond to scroll wheel events. Useful when the slider sits inside a scrolling
+    /// container.
     fn disable_scroll_wheel(self) -> Self;
 
     /// Change how the [`ParamSlider`] visualizes the current value.
     fn set_style(self, style: ParamSliderStyle) -> Self;
 
-    /// Manually set a fixed label for the slider instead of displaying the current value. This is
-    /// currently not reactive.
+    /// Manually set a fixed label for the slider instead of displaying the current value.
     fn with_label(self, value: impl Into<String>) -> Self;
 }
 
@@ -617,12 +589,12 @@ impl ParamSliderExt for Handle<'_, ParamSlider> {
     }
 
     fn set_style(self, style: ParamSliderStyle) -> Self {
-        self.modify(|param_slider: &mut ParamSlider| param_slider.style = style)
+        self.modify(|param_slider: &mut ParamSlider| param_slider.style.set(style))
     }
 
     fn with_label(self, value: impl Into<String>) -> Self {
         self.modify(|param_slider: &mut ParamSlider| {
-            param_slider.label_override = Some(value.into())
+            param_slider.label_override.set(Some(value.into()));
         })
     }
 }

--- a/src/widgets/peak_meter.rs
+++ b/src/widgets/peak_meter.rs
@@ -105,7 +105,7 @@ impl PeakMeter {
                                 .class("ticks__label")
                                 .class("ticks__label--dbfs")
                         } else {
-                            Label::new(cx, &tick_db.to_string()).class("ticks__label")
+                            Label::new(cx, tick_db.to_string()).class("ticks__label")
                         };
                     })
                     .width(Auto)

--- a/src/widgets/peak_meter.rs
+++ b/src/widgets/peak_meter.rs
@@ -16,91 +16,97 @@ const TICK_GAP: f32 = 1.0;
 const MIN_TICK: f32 = -90.0;
 /// The decibel value corresponding to the very right of the bar.
 const MAX_TICK: f32 = 20.0;
-/// The ticks that will be shown beneath the peak meter's bar. The first value is shown as
-/// -infinity, and at the last position we'll draw the `dBFS` string.
+/// The ticks shown beneath the peak meter's bar. The first value is shown as -infinity, and at
+/// the last position we draw the `dBFS` string.
 const TEXT_TICKS: [i32; 6] = [-80, -60, -40, -20, 0, 12];
+
+/// How often the bar repaints to drive wall-clock-based hold-peak decay when the level signal
+/// itself isn't updating (e.g. the source has gone silent). 20 Hz is fast enough to feel
+/// responsive at typical hold times (~600 ms) and cheap enough to ignore.
+const DECAY_TICK_INTERVAL: Duration = Duration::from_millis(50);
 
 /// A simple horizontal peak meter.
 ///
-/// TODO: There are currently no styling options at all
-/// TODO: Vertical peak meter, this is just a proof of concept to fit the gain GUI example.
+/// TODO: There are currently no styling options at all.
+/// TODO: Vertical peak meter — this is just a proof of concept to fit the gain GUI example.
 pub struct PeakMeter;
 
 /// The bar bit for the peak meter, manually drawn using vertical lines.
-struct PeakMeterBar<L, P>
-where
-    L: Lens<Target = f32>,
-    P: Lens<Target = f32>,
-{
-    level_dbfs: L,
-    peak_dbfs: P,
+///
+/// Holds the current level signal, the optional hold-time, and (for the hold-peak display)
+/// two `Cell`s tracking the latched peak value and the instant it was latched. The hold
+/// computation lives in [`View::draw`] so it runs off a wall clock — that way the held peak
+/// decays after `hold_time` even when the source signal stops updating (e.g. silent audio).
+struct PeakMeterBar {
+    level_dbfs: SyncSignal<f32>,
+    hold_time: Option<Duration>,
+    held_peak_dbfs: Cell<f32>,
+    last_held_at: Cell<Option<Instant>>,
 }
 
 impl PeakMeter {
-    /// Creates a new [`PeakMeter`] for the given value in decibel, optionally holding the peak
-    /// value for a certain amount of time.
-    pub fn new<L>(cx: &mut Context, level_dbfs: L, hold_time: Option<Duration>) -> Handle<Self>
-    where
-        L: Lens<Target = f32>,
-    {
-        Self.build(cx, |cx| {
-            // Now for something that may be illegal under some jurisdictions. If a hold time is
-            // given, then we'll build a new lens that always gives the held peak level for the
-            // current moment in time by mutating some values captured into the mapping closure.
-            let held_peak_value_db = Cell::new(f32::MIN);
-            let last_held_peak_value: Cell<Option<Instant>> = Cell::new(None);
-            let peak_dbfs = level_dbfs.map(move |level| -> f32 {
-                match hold_time {
-                    Some(hold_time) => {
-                        let mut peak_level = held_peak_value_db.get();
-                        let peak_time = last_held_peak_value.get();
-
-                        let now = Instant::now();
-                        if *level >= peak_level
-                            || peak_time.is_none()
-                            || now > peak_time.unwrap() + hold_time
-                        {
-                            peak_level = *level;
-                            held_peak_value_db.set(peak_level);
-                            last_held_peak_value.set(Some(now));
-                        }
-
-                        peak_level
-                    }
-                    None => util::MINUS_INFINITY_DB,
-                }
-            });
-
-            PeakMeterBar {
+    /// Creates a new [`PeakMeter`] reading from the given dBFS signal. If `hold_time` is set,
+    /// the peak value is latched for that duration before decaying.
+    ///
+    /// Typical setup: an `Arc<AtomicF32>` (or similar) updated by the audio thread, mirrored
+    /// into a `SyncSignal<f32>` from a periodic UI-side tick. See the `gain_gui` example.
+    pub fn new(
+        cx: &mut Context,
+        level_dbfs: SyncSignal<f32>,
+        hold_time: Option<Duration>,
+    ) -> Handle<'_, Self> {
+        Self.build(cx, move |cx| {
+            // `PeakMeterBar` paints directly from the `level_dbfs` signal (read inside
+            // `draw()`). A signal read from `draw()` does *not* register the view for
+            // redraws, so we explicitly bind to `level_dbfs` for the "level changed →
+            // repaint" path.
+            let bar = PeakMeterBar {
                 level_dbfs,
-                peak_dbfs,
+                hold_time,
+                held_peak_dbfs: Cell::new(f32::MIN),
+                last_held_at: Cell::new(None),
             }
             .build(cx, |_| {})
-            .class("bar");
+            .class("bar")
+            .bind(level_dbfs, |mut handle| handle.needs_redraw());
+
+            let bar_entity = bar.entity();
+
+            // When `hold_time` is set, the held-peak value decays on wall-clock time. If the
+            // source goes silent, `level_dbfs` stops changing and the `bind` above stops
+            // triggering repaints — the held peak would stay stuck forever without this
+            // timer nudging a repaint periodically. `draw()` reads `Instant::now()` and
+            // expires the hold on its own.
+            if hold_time.is_some() {
+                let decay_timer = cx.add_timer(DECAY_TICK_INTERVAL, None, move |cx, action| {
+                    if matches!(action, TimerAction::Tick(_)) {
+                        cx.with_current(bar_entity, |cx| cx.needs_redraw());
+                    }
+                });
+                cx.start_timer(decay_timer);
+            }
 
             HStack::new(cx, |cx| {
                 for tick_db in TEXT_TICKS {
                     let first_tick = tick_db == TEXT_TICKS[0];
                     let last_tick = tick_db == TEXT_TICKS[TEXT_TICKS.len() - 1];
                     VStack::new(cx, |cx| {
-                        
                         if !last_tick {
                             Element::new(cx).class("ticks__tick");
                         }
-                        
+
                         if first_tick {
                             Label::new(cx, "-inf")
                                 .class("ticks__label")
                                 .class("ticks__label--inf")
                         } else if last_tick {
-                            // This is only inclued in the array to make positioning this easier
+                            // Only in the array to make positioning easier.
                             Label::new(cx, "dBFS")
                                 .class("ticks__label")
                                 .class("ticks__label--dbfs")
                         } else {
                             Label::new(cx, &tick_db.to_string()).class("ticks__label")
                         };
-
                     })
                     .width(Auto)
                     .alignment(Alignment::TopCenter);
@@ -108,13 +114,9 @@ impl PeakMeter {
                     if !last_tick {
                         Spacer::new(cx);
                     }
-                    
                 }
             })
             .class("ticks");
-        })
-        .bind(level_dbfs, |mut handle, _|{
-            handle.needs_redraw();
         })
     }
 }
@@ -125,23 +127,50 @@ impl View for PeakMeter {
     }
 }
 
-impl<L, P> View for PeakMeterBar<L, P>
-where
-    L: Lens<Target = f32>,
-    P: Lens<Target = f32>,
-{
-    fn draw(&self, cx: &mut DrawContext, canvas: &Canvas) {
-        let level_dbfs = self.level_dbfs.get(cx);
-        let peak_dbfs = self.peak_dbfs.get(cx);
+impl PeakMeterBar {
+    /// Compute the current hold-peak dBFS value. Called from `draw()` — runs on the UI
+    /// thread, uses wall-clock time, mutates the `Cell` state in place.
+    fn update_held_peak(&self, current_level_dbfs: f32) -> f32 {
+        let Some(hold_time) = self.hold_time else {
+            // No hold configured — the display shows `MINUS_INFINITY_DB` as a sentinel so
+            // the draw path can skip drawing the hold tick.
+            return util::MINUS_INFINITY_DB;
+        };
 
-        // These basics are taken directly from the default implementation of this function
+        let now = Instant::now();
+        let mut held = self.held_peak_dbfs.get();
+        let held_at = self.last_held_at.get();
+
+        if current_level_dbfs >= held
+            || held_at.is_none()
+            || now > held_at.unwrap() + hold_time
+        {
+            held = current_level_dbfs;
+            self.held_peak_dbfs.set(held);
+            self.last_held_at.set(Some(now));
+        }
+
+        held
+    }
+}
+
+impl View for PeakMeterBar {
+    fn element(&self) -> Option<&'static str> {
+        Some("peak-meter-bar")
+    }
+
+    fn draw(&self, cx: &mut DrawContext, canvas: &Canvas) {
+        let level_dbfs = self.level_dbfs.get();
+        let peak_dbfs = self.update_held_peak(level_dbfs);
+
+        // These basics are taken directly from the default implementation of this function.
         let bounds = cx.bounds();
         if bounds.w == 0.0 || bounds.h == 0.0 {
             return;
         }
 
-        // TODO: It would be cool to allow the text color property to control the gradient here. For
-        //       now we'll only support basic background colors and borders.
+        // TODO: It would be nice to let the text colour property drive the gradient here. For
+        //       now we only support basic background colours and borders.
         let background_color = cx.background_color();
         let border_color = cx.border_color();
         let border_width = cx.border_width();
@@ -160,58 +189,53 @@ where
             path.close();
         }
 
-        // Fill with background color
+        // Fill with background colour.
         let mut paint = vg::Paint::default();
         paint.set_color(background_color);
         canvas.draw_path(&path.snapshot(), &paint);
 
-        // And now for the fun stuff. We'll try to not overlap the border, but we'll draw that last
-        // just in case.
+        // Now the fun stuff. Try not to overlap the border, but draw that last just in case.
         let bar_bounds = bounds.shrink(border_width / 2.0);
         let bar_ticks_start_x = bar_bounds.left().floor() as i32;
         let bar_ticks_end_x = bar_bounds.right().ceil() as i32;
 
-        // NOTE: We'll scale this with the nearest integer DPI ratio. That way it will still look
-        //       good at 2x scaling, and it won't look blurry at 1.x times scaling.
+        // NOTE: We scale this with the nearest integer DPI ratio. That way it still looks good
+        //       at 2× scaling and isn't blurry at 1.x× scaling.
         let dpi_scale = cx.logical_to_physical(1.0).floor().max(1.0);
         let bar_tick_coordinates = (bar_ticks_start_x..bar_ticks_end_x)
             .step_by(((TICK_WIDTH + TICK_GAP) * dpi_scale).round() as usize);
         for tick_x in bar_tick_coordinates {
-            let tick_fraction =
-                (tick_x - bar_ticks_start_x) as f32 / (bar_ticks_end_x - bar_ticks_start_x) as f32;
+            let tick_fraction = (tick_x - bar_ticks_start_x) as f32
+                / (bar_ticks_end_x - bar_ticks_start_x) as f32;
             let tick_db = (tick_fraction * (MAX_TICK - MIN_TICK)) + MIN_TICK;
             if tick_db > level_dbfs {
                 break;
             }
 
-            // femtovg draws paths centered on these coordinates, so in order to be pixel perfect we
-            // need to account for that. Otherwise the ticks will be 2px wide instead of 1px.
+            // femtovg draws paths centred on these coordinates, so for pixel-perfect rendering
+            // we need to account for that — otherwise the ticks will be 2px wide instead of 1px.
             let mut path = vg::PathBuilder::new();
             path.move_to((tick_x as f32 + (dpi_scale / 2.0), bar_bounds.top()));
             path.line_to((tick_x as f32 + (dpi_scale / 2.0), bar_bounds.bottom()));
 
             let grayscale_color = 0.3 + ((1.0 - tick_fraction) * 0.5);
             let mut paint = vg::Paint::default();
-            paint.set_color4f(vg::Color4f::new(
-                grayscale_color,
-                grayscale_color,
-                grayscale_color,
-                1.0
-            ), None);
+            paint.set_color4f(
+                vg::Color4f::new(grayscale_color, grayscale_color, grayscale_color, 1.0),
+                None,
+            );
             paint.set_stroke_width(TICK_WIDTH * dpi_scale);
             paint.set_style(vg::PaintStyle::Stroke);
             canvas.draw_path(&path.snapshot(), &paint);
         }
 
-        // Draw the hold peak value if the hold time option has been set
+        // Draw the hold peak value if the hold time option was set.
         let db_to_x_coord = |db: f32| {
             let tick_fraction = (db - MIN_TICK) / (MAX_TICK - MIN_TICK);
             bar_ticks_start_x as f32
                 + ((bar_ticks_end_x - bar_ticks_start_x) as f32 * tick_fraction).round()
         };
         if (MIN_TICK..MAX_TICK).contains(&peak_dbfs) {
-            // femtovg draws paths centered on these coordinates, so in order to be pixel perfect we
-            // need to account for that. Otherwise the ticks will be 2px wide instead of 1px.
             let peak_x = db_to_x_coord(peak_dbfs);
             let mut path = vg::PathBuilder::new();
             path.move_to((peak_x + (dpi_scale / 2.0), bar_bounds.top()));
@@ -224,7 +248,7 @@ where
             canvas.draw_path(&path.snapshot(), &paint);
         }
 
-        // Draw border last
+        // Draw border last.
         let mut paint = vg::Paint::default();
         paint.set_color(border_color);
         paint.set_stroke_width(border_width);


### PR DESCRIPTION
> Paired with companion vizia PR [vizia#634](https://github.com/vizia/vizia/pull/634) and RFC issue [vizia-plug#14](https://github.com/vizia/vizia-plug/issues/14). geom3trik confirmed option 2 as the bridge shape on #14.

## Summary

Rebases vizia-plug onto current vizia `main` (`12ff2584`, post-`#627` widgets-update) and ports every param widget to the signal-based `Binding` API introduced by [vizia#619](https://github.com/vizia/vizia/pull/619).

## What's in

### `ParamWidgetBase` API (addresses Q1 + Q3 from #14)
- `ParamWidgetBase::new(cx, &P)` — no more `Arc<Params> + params_to_param` ceremony. Callers write `ParamSlider::new(cx, &params.gain)`.
- `ParamWidgetData<'a, P>` carries a safe lifetime-bound borrow — dropped the `&'static P` transmute.
- `ParamWidgetBase` is `Copy` so widgets can freely capture it into `'static` `Binding::new` closures.

### Bridge between nih-plug's pull-based params and vizia's push-based signals
- New `ParamRegistry` (cheap `Arc`-wrapped, `parking_lot::Mutex` internally) owns one `SyncSignal<f32>` per `(ParamPtr, axis)`. Lazily created on first widget access.
- Installed as a vizia `Model` during editor spawn; widgets access via `cx.data::<ParamRegistry>()`.
- `Editor::parameter_value_changed` / `parameter_values_changed` call `registry.flush_all()` to mirror current `ParamPtr` values into the signals. Audio-thread writes enqueue effects in `SYNC_RUNTIME`; the UI side drains them.

### Widgets
- `param_slider.rs` — style / label_override / text_input_active as `SyncSignal`s. Derived display values via `Memo::new(|_| { sig_a.get(); sig_b.get(); ... })` for proper reactive dependency tracking. `compute_modulation_fill_start_delta` is now a pure function of values.
- `peak_meter.rs` — takes `SyncSignal<f32>`. Hold-peak state on `Cell` fields + internal decay timer so wall-clock decay works even when audio goes silent.
- `generic_ui.rs` — takes `&Ps` directly, no lens / `AsRef` ceremony.
- `param_button.rs` — simplified to match.

### Example
`examples/gain_gui` ported to the new API. Demonstrates the atomic→`SyncSignal` bridge via a short vizia `Timer` (the canonical pattern for audio→UI where nih-plug's parameter callbacks don't apply).

## Companion vizia PR

**This PR depends on [vizia#634](https://github.com/vizia/vizia/pull/634)** for full correctness, but works standalone.

vizia#634 adds the sync-runtime integration to `vizia_baseview` that `vizia_winit` already has (`Runtime::drain_pending_work()` in `on_frame_update`, sync effect waker registration, `Runtime` re-exported from `vizia_core::prelude`). Until that lands, vizia-plug carries a belt-and-suspenders `Runtime::drain_pending_work()` call in its own `on_idle` callback via a direct `vizia_reactive` dep. Once vizia#634 merges:
- Drop the direct `vizia_reactive` dep
- Remove the `on_idle` drain (baseview handles it)
- Both changes are pure deletions — no API impact

## Known limitations (pre-existing, not ours to fix)

- **Binding-time memo accumulation**: every time an outer `Binding::new` rebuilds (e.g. `.set_style()` on a slider), the inner memos are recreated but never disposed. One-shot style sets in practice, no correctness issue.
- **Registry signals never disposed**: per-param signals accumulate until the editor closes. Fine for long-lived plugin editors; worth revisiting if we ever build reopen-heavy tooling.
- **`on_idle` vs `on_frame`**: without vizia#634, the `Runtime::drain_pending_work()` call only fires on `on_idle` (which is not called every frame in baseview — only inside `on_event`). This means host-driven automation on an otherwise idle editor can take one user-event to surface. vizia#634 fixes this properly.

## Gates

`cargo check --workspace`, `cargo clippy --lib`, `cargo fmt --check` — all pass.