### PR TITLE
Update nih_plug dependency to new BillyDM fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = ["xtask", "examples/gain_gui"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git" }
+nih_plug = { git = "https://github.com/BillyDM/nih-plug.git" }
 vizia = { git = "https://github.com/vizia/vizia", rev = "12ff2584", default-features = false, features = ["baseview", "clipboard", "x11"] }
 # vizia = { path = "../vizia", default_features = false, features = ["baseview", "clipboard", "x11"] }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nih_plug_xtask = { git = "https://github.com/robbert-vdh/nih-plug.git" }
+nih_plug_xtask = { git = "https://github.com/BillyDM/nih-plug.git" }


### PR DESCRIPTION
Since Robert apparently no longer has time to maintain the nih_plug library, BillyDM has stepped in and established a fork.

I've tested my own plugin with the new dependencies and everything compiles cleanly — albeit only under Windows.

I think it would be interesting for many vizia-plug users to make this switch.