### PR TITLE
refactor(param-widgets): address #13 inline review feedback

### DIFF
--- a/src/widgets/param_button.rs
+++ b/src/widgets/param_button.rs
@@ -27,12 +27,6 @@ pub struct ParamButton {
 impl ParamButton {
     /// Creates a new [`ParamButton`] for the given parameter. Pass a reference to the
     /// parameter directly — e.g. `ParamButton::new(cx, &params.my_toggle)`.
-    ///
-    /// The `'p: 'c` bound reads as "the parameter must outlive the context borrow": the
-    /// builder closure captured into `cx` borrows `param` to resolve static metadata, so the
-    /// parameter's storage (normally inside the plugin's `Arc<Params>`) has to stay alive at
-    /// least as long as the widget is being built. In practice this is always true — `Params`
-    /// lives for the plugin's lifetime — the bound just lets the borrow checker prove it.
     pub fn new<'c, 'p, P>(cx: &'c mut Context, param: &'p P) -> Handle<'c, Self>
     where
         'p: 'c,
@@ -52,10 +46,13 @@ impl ParamButton {
             cx,
             ParamWidgetBase::build_view(param, move |cx, param_data| {
                 let param_name = param_data.param().name().to_owned();
-                Binding::new(cx, label_override, move |cx| {
-                    let text = label_override.get().unwrap_or_else(|| param_name.clone());
-                    Label::new(cx, text).hoverable(false);
-                });
+                // Derived label text: either the `.with_label(...)` override when set, or the
+                // parameter's own name. Built as a `Memo<String>` so the Label updates its
+                // text in place when the override changes — cheaper than rebuilding the view
+                // subtree via `Binding::new`.
+                let text: Memo<String> =
+                    Memo::new(move |_| label_override.get().unwrap_or_else(|| param_name.clone()));
+                Label::new(cx, text).hoverable(false);
             }),
         )
         // `:checked` pseudo-class when the button is on. Uses modulated value — there's no

--- a/src/widgets/param_registry.rs
+++ b/src/widgets/param_registry.rs
@@ -63,7 +63,9 @@ impl ParamRegistry {
     /// Creates an empty registry.
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(ParamRegistryInner { signals: Mutex::new(HashMap::new()) }),
+            inner: Arc::new(ParamRegistryInner {
+                signals: Mutex::new(HashMap::new()),
+            }),
         }
     }
 
@@ -96,8 +98,10 @@ impl ParamRegistry {
     }
 
     /// Re-read every registered parameter via unsafe `ParamPtr` and write the current value
-    /// into its signal. Intended to be called from the editor's `parameter_value_changed` /
-    /// `parameter_values_changed` hooks; the reactive graph then notifies any bound widgets.
+    /// into its signal. Intended to be called from the editor's
+    /// [`parameter_values_changed`](nih_plug::prelude::Editor::parameter_values_changed) hook
+    /// (which reports "something moved but we don't know what") so every widget catches up
+    /// in one sweep.
     pub fn flush_all(&self) {
         let signals = self.inner.signals.lock();
 
@@ -110,6 +114,32 @@ impl ParamRegistry {
                 }
             };
             signal.set_if_changed(current);
+        }
+    }
+
+    /// Re-read a single parameter via unsafe `ParamPtr` and write its current value into each
+    /// of its registered axis signals (modulated + unmodulated). Intended to be called from
+    /// the editor's
+    /// [`parameter_value_changed`](nih_plug::prelude::Editor::parameter_value_changed) /
+    /// [`parameter_modulation_changed`](nih_plug::prelude::Editor::parameter_modulation_changed)
+    /// hooks — both of which report the specific parameter that moved — so a single-parameter
+    /// change doesn't iterate every signal in the registry.
+    ///
+    /// Axes with no signal registered for this parameter are silently skipped.
+    pub fn flush_one(&self, param_ptr: ParamPtr) {
+        let signals = self.inner.signals.lock();
+
+        for axis in [ParamAxis::Modulated, ParamAxis::Unmodulated] {
+            if let Some(signal) = signals.get(&(param_ptr, axis)) {
+                // SAFETY: see `signal()`.
+                let current = unsafe {
+                    match axis {
+                        ParamAxis::Modulated => param_ptr.modulated_normalized_value(),
+                        ParamAxis::Unmodulated => param_ptr.unmodulated_normalized_value(),
+                    }
+                };
+                signal.set_if_changed(current);
+            }
         }
     }
 }

--- a/src/widgets/param_slider.rs
+++ b/src/widgets/param_slider.rs
@@ -82,12 +82,6 @@ impl ParamSlider {
     /// Parameter changes are handled by emitting [`ParamEvent`](super::ParamEvent)s, which
     /// are automatically processed by the vizia-plug wrapper.
     ///
-    /// The `'p: 'c` bound reads as "the parameter must outlive the context borrow": the
-    /// builder closure captured into `cx` borrows `param` to resolve static metadata, so the
-    /// parameter's storage (normally inside the plugin's `Arc<Params>`) has to stay alive at
-    /// least as long as the widget is being built. In practice this is always true — `Params`
-    /// lives for the plugin's lifetime — the bound just lets the borrow checker prove it.
-    ///
     /// See [`ParamSliderExt`] for additional options.
     pub fn new<'c, 'p, P>(cx: &'c mut Context, param: &'p P) -> Handle<'c, Self>
     where
@@ -256,8 +250,7 @@ impl ParamSlider {
                     // here rather than threading it through the reactive graph.
                     for value in 0..step_count + 1 {
                         let normalized_value = value as f32 / step_count as f32;
-                        let preview = param_base
-                            .normalized_value_to_string(normalized_value, true);
+                        let preview = param_base.normalized_value_to_string(normalized_value, true);
 
                         Label::new(cx, preview)
                             .class("value")
@@ -272,19 +265,18 @@ impl ParamSlider {
                 .hoverable(false);
             }
             _ => {
-                Binding::new(cx, label_override, move |cx| {
-                    // If the label override is set, use it. Otherwise show the parameter's
-                    // current display value (before modulation).
-                    match label_override.get() {
-                        Some(label) => Label::new(cx, label),
-                        None => Label::new(cx, display_value),
-                    }
+                // Derived label text: either the `.with_label(...)` override when set, or the
+                // parameter's own formatted display value (before modulation). Built as a
+                // `Memo<String>` so the Label updates its text in place when either input
+                // changes — cheaper than rebuilding the view subtree via `Binding::new`.
+                let text: Memo<String> =
+                    Memo::new(move |_| label_override.get().unwrap_or_else(|| display_value.get()));
+                Label::new(cx, text)
                     .class("value")
                     .class("value--single")
                     .alignment(Alignment::Center)
                     .size(Stretch(1.0))
                     .hoverable(false);
-                });
             }
         }
     }
@@ -401,9 +393,7 @@ impl View for ParamSlider {
                 meta.consume();
             }
             ParamSliderEvent::TextInput(string) => {
-                if let Some(normalized_value) =
-                    self.param_base.string_to_normalized_value(string)
-                {
+                if let Some(normalized_value) = self.param_base.string_to_normalized_value(string) {
                     self.param_base.begin_set_parameter(cx);
                     self.param_base.set_normalized_value(cx, normalized_value);
                     self.param_base.end_set_parameter(cx);
@@ -487,20 +477,16 @@ impl View for ParamSlider {
                     // If shift is held, dragging is granular rather than absolute.
                     if cx.modifiers().shift() {
                         let granular_drag_status =
-                            *self.granular_drag_status.get_or_insert_with(|| {
-                                GranularDragStatus {
+                            *self
+                                .granular_drag_status
+                                .get_or_insert_with(|| GranularDragStatus {
                                     starting_x_coordinate: *x,
-                                    starting_value: self
-                                        .param_base
-                                        .unmodulated_normalized_value(),
-                                }
-                            });
+                                    starting_value: self.param_base.unmodulated_normalized_value(),
+                                });
 
                         // Compensate for the DPI scale to keep the drag consistent.
-                        let start_x = util::remap_current_entity_x_t(
-                            cx,
-                            granular_drag_status.starting_value,
-                        );
+                        let start_x =
+                            util::remap_current_entity_x_t(cx, granular_drag_status.starting_value);
                         let delta_x = ((*x - granular_drag_status.starting_x_coordinate)
                             * GRANULAR_DRAG_MULTIPLIER)
                             * cx.scale_factor();


### PR DESCRIPTION
Follow-up to #13 addressing the inline review comments. Each change is a separate commit so they can be reviewed independently.

## Changes

### 1. `refactor(param_button): use Memo for label; trim 'p: 'c doc` — `be83f6a`
Addresses:
- `src/widgets/param_button.rs:57` — *"I think you could use a memo or signal map here to avoid the binding and just update the label value rather than rebuilding the entire label."*
- `src/widgets/param_button.rs:35` — *"I wonder if users of this method need to know this bit?"*

### 2. `refactor(param_slider): use Memo for label; trim 'p: 'c doc` — `11163d4`
Addresses:
- `src/widgets/param_slider.rs:275` — *"Same as above. Could use a memo to avoid the Binding."*
- The same `'p: 'c` paragraph also appeared on `ParamSlider::new`; trimmed for consistency. The `CurrentStepLabeled` multi-label HStack is untouched (those labels are built once from static metadata).

### 3. `feat(registry): add ParamRegistry::flush_one` — `ac0cd57`
Addresses:
- `src/widgets/param_registry.rs:101` — *"I wonder if there should be a version of this that flushes a specific parameter?"*

`flush_one(param_ptr)` mirrors `flush_all` but only reads + writes the signals for one `ParamPtr`, across both axes. Intended for the per-parameter editor hooks (`parameter_value_changed` / `parameter_modulation_changed`); `flush_all` stays appropriate for the batch `parameter_values_changed`. I deliberately did not wire the editor callbacks to use `flush_one` in this PR — `parameter_value_changed` receives an `id: &str` and converting that to a `ParamPtr` inside the registry would need a reverse-lookup map (or scanning all entries); happy to follow that up if you'd like.

## Inline comments I didn't act on

- `src/widgets/param_button.rs:20` — *"wonder if this could just be a regular `Signal`? Or is there a specific reason to use `SyncSignal` here?"* — The widget-local signals (`label_override`, `text_input_active`, `style`) are only touched from the UI thread, so `Signal<T>` would work. `SyncSignal` was the defensive default to match the registry signals the widget pairs with. Happy to flip everything to `Signal` in a follow-up if you prefer it — it's a pure type-name replacement for these internal fields. Left as-is here to keep the PR focused on the `Memo` + `flush_one` changes.
- `src/widgets/param_button.rs:140` (`with_label` taking a `Res` in future) — noted, tracked for a follow-up.
- `src/widgets/peak_meter.rs:216` (skia vs femtovg) — understood as your own cleanup note.

## Test plan

- [x] `cargo check` clean
- [x] `cargo fmt` clean on the three touched files
- [x] Runtime-validated downstream: swapped Bitform's `[patch]` at this branch + re-bundled — knob drag, modulation, context menu, label override via a custom widget wrapper all still work end-to-end in REAPER + Ableton.

## Summary question on #13 — xy-pad / multi-parameter widgets

Short answer: yes, fully supported. The widget struct holds one `ParamWidgetBase` per parameter, and derived reactive values compose via `Memo`:

```rust
pub struct XyPad {
    x_base: ParamWidgetBase,
    y_base: ParamWidgetBase,
}

impl XyPad {
    pub fn new<'c, 'px, 'py, PX, PY>(
        cx: &'c mut Context,
        x_param: &'px PX,
        y_param: &'py PY,
    ) -> Handle<'c, Self>
    where
        'px: 'c,
        'py: 'c,
        PX: Param + 'static,
        PY: Param + 'static,
    {
        let x_base = ParamWidgetBase::new(cx, x_param);
        let y_base = ParamWidgetBase::new(cx, y_param);
        let x_sig = x_base.unmodulated_signal(cx);
        let y_sig = y_base.unmodulated_signal(cx);

        // Derived pad-dot position — recomputes whenever either axis moves.
        let position: Memo<(f32, f32)> = Memo::new(move |_| (x_sig.get(), y_sig.get()));

        Self { x_base, y_base }.build(cx, /* content bound to `position` */)
    }
}
```

The `'static`-for-each-signal + `Memo::new(move |_| { a.get(); b.get(); ... })` pattern scales to any number of parameters. The one thing to watch is that each `.get()` call inside the `Memo` closure subscribes the effect to that signal — dropping one means the Memo won't re-run when that axis changes.

