### PR TITLE
Implement Editor::on_virtual_key_from_host for VST3 text-input routing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 nih_plug = { git = "https://github.com/BillyDM/nih-plug.git" }
-vizia = { git = "https://github.com/vizia/vizia", rev = "12ff2584", default-features = false, features = ["baseview", "clipboard", "x11"] }
+vizia = { git = "https://github.com/vizia/vizia", rev = "23e34039", default-features = false, features = ["baseview", "clipboard", "x11"] }
 # vizia = { path = "../vizia", default_features = false, features = ["baseview", "clipboard", "x11"] }
 
 # Direct dependency on `vizia_reactive` so the editor can call
@@ -26,7 +26,7 @@ vizia = { git = "https://github.com/vizia/vizia", rev = "12ff2584", default-feat
 # AND `vizia_baseview`'s `on_frame_update` calls `Runtime::drain_pending_work()`
 # itself (matching what `vizia_winit` already does). Tracked in the companion
 # vizia PR — see CHANGELOG / PR description for the link.
-vizia_reactive = { git = "https://github.com/vizia/vizia", rev = "12ff2584", default-features = false }
+vizia_reactive = { git = "https://github.com/vizia/vizia", rev = "23e34039", default-features = false }
 
 crossbeam = "0.8"
 # Used by `ParamRegistry` for its signal map — flushing happens from the host /

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,6 +1,5 @@
 //! The [`Editor`] trait implementation for Vizia editors.
 
-
 use crossbeam::atomic::AtomicCell;
 use nih_plug::debug::*;
 use nih_plug::prelude::{Editor, GuiContext, Modifiers, ParentWindowHandle, VirtualKeyCode};
@@ -12,9 +11,9 @@ use vizia::views::TextEvent;
 
 use vizia_reactive::Runtime;
 
-use crate::widgets::param_registry::ParamRegistry;
 use crate::widgets::RawParamEvent;
-use crate::{widgets, ViziaState, ViziaTheming};
+use crate::widgets::param_registry::ParamRegistry;
+use crate::{ViziaState, ViziaTheming, widgets};
 
 /// A key-down event queued by the host-thread
 /// `Editor::on_virtual_key_from_host` callback, waiting for the next
@@ -114,18 +113,18 @@ impl Editor for ViziaEditor {
         let mut application = Application::new(move |cx| {
             // Set some default styles to match the iced integration
             //if theming >= ViziaTheming::Custom {
-                // NOTE: `Context::set_default_font` was removed upstream as a deprecated API
-                // (vizia commit ff943a0b, "Context: remove deprecated APIs and clarify docs").
-                // The default font is now controlled through stylesheets — `theme.css` below
-                // can set `* { font-family: ...; }` if a specific font is required.
-                if let Err(err) = cx.add_stylesheet(include_style!("src/assets/theme.css")) {
-                    nih_error!("Failed to load stylesheet: {err:?}");
-                    panic!();
-                }
+            // NOTE: `Context::set_default_font` was removed upstream as a deprecated API
+            // (vizia commit ff943a0b, "Context: remove deprecated APIs and clarify docs").
+            // The default font is now controlled through stylesheets — `theme.css` below
+            // can set `* { font-family: ...; }` if a specific font is required.
+            if let Err(err) = cx.add_stylesheet(include_style!("src/assets/theme.css")) {
+                nih_error!("Failed to load stylesheet: {err:?}");
+                panic!();
+            }
 
-                // There doesn't seem to be any way to bundle styles with a widget, so we'll always
-                // include the style sheet for our custom widgets at context creation
-                widgets::register_theme(cx);
+            // There doesn't seem to be any way to bundle styles with a widget, so we'll always
+            // include the style sheet for our custom widgets at context creation
+            widgets::register_theme(cx);
             //}
 
             // Install the parameter signal registry so widgets can find it via
@@ -197,10 +196,9 @@ impl Editor for ViziaEditor {
                 // synchronously whether to claim a key. The element
                 // name `"textbox"` is set by
                 // `vizia::views::Textbox::element()`.
-                key_inject.text_focused.store(
-                    cx.focused_element() == Some("textbox"),
-                    Ordering::Release,
-                );
+                key_inject
+                    .text_focused
+                    .store(cx.focused_element() == Some("textbox"), Ordering::Release);
 
                 // Drain any keys queued by `on_virtual_key_from_host`
                 // and dispatch them to the focused view. Buffered
@@ -216,10 +214,7 @@ impl Editor for ViziaEditor {
                 // key handler (e.g. textbox's `KeyDown` match arm)
                 // runs.
                 let drained: Vec<KeyInject> = {
-                    let mut q = key_inject
-                        .pending
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner());
+                    let mut q = key_inject.pending.lock().unwrap_or_else(|e| e.into_inner());
                     q.drain(..).collect()
                 };
                 if !drained.is_empty() {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3,16 +3,67 @@
 
 use crossbeam::atomic::AtomicCell;
 use nih_plug::debug::*;
-use nih_plug::prelude::{Editor, GuiContext, ParentWindowHandle};
+use nih_plug::prelude::{Editor, GuiContext, Modifiers, ParentWindowHandle, VirtualKeyCode};
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use vizia::prelude::*;
+use vizia::views::TextEvent;
 
 use vizia_reactive::Runtime;
 
 use crate::widgets::param_registry::ParamRegistry;
 use crate::widgets::RawParamEvent;
 use crate::{widgets, ViziaState, ViziaTheming};
+
+/// A key-down event queued by the host-thread
+/// `Editor::on_virtual_key_from_host` callback, waiting for the next
+/// `on_idle` tick to dispatch on the GUI thread.
+///
+/// Split between character input (goes through `TextEvent::InsertText`)
+/// and non-printable control keys (goes through `WindowEvent::KeyDown`)
+/// so the GUI-thread drain stays trivially correct without having to
+/// re-guess a key's semantics: the classification is made on the host
+/// thread from the host's virtual key code.
+pub(crate) enum KeyInject {
+    /// A printable character (derived from a virtual key that maps 1:1
+    /// to a printable character: Space, Numpad0..Numpad9, the numpad
+    /// operator keys, Equals). Dispatched as `TextEvent::InsertText`.
+    Char(char),
+    /// A non-printable key (Backspace, Enter, Tab, Escape, arrows,
+    /// Home/End, Delete, F-keys, etc.). Dispatched as
+    /// `WindowEvent::KeyDown(code, Some(key))` so the target view's
+    /// own key handling (e.g. textbox's `WindowEvent::KeyDown`
+    /// match arm) runs.
+    ControlKey(Code, Key),
+}
+
+/// State shared between [`ViziaEditor`] (invoked from the host UI
+/// thread) and the vizia `on_idle` callback (invoked on the GUI thread).
+///
+/// The `Editor::on_virtual_key_from_host` callback runs on the host
+/// thread and cannot reach into the live vizia `Context`. Instead, it
+/// consults `text_focused` (kept in sync from `on_idle`) to decide
+/// whether to claim the key, and pushes a [`KeyInject`] into `pending`.
+/// The next `on_idle` tick drains the queue and dispatches each entry
+/// to the currently focused entity.
+pub(crate) struct KeyInjectState {
+    /// `true` while the vizia focused view reports element name `"textbox"`.
+    /// Updated on every `on_idle` tick.
+    text_focused: AtomicBool,
+    /// Keys the host delivered via the virtual-key hook that still need
+    /// to be dispatched into the focused view on the next idle tick.
+    pending: Mutex<VecDeque<KeyInject>>,
+}
+
+impl KeyInjectState {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            text_focused: AtomicBool::new(false),
+            pending: Mutex::new(VecDeque::new()),
+        })
+    }
+}
 
 /// An [`Editor`] implementation that calls a vizia draw loop.
 pub(crate) struct ViziaEditor {
@@ -38,6 +89,11 @@ pub(crate) struct ViziaEditor {
     /// `parameter_value_changed` / `parameter_values_changed` hooks so the reactive graph picks
     /// up value changes that nih-plug reports.
     pub(crate) param_registry: ParamRegistry,
+
+    /// Shared state bridging the host-thread
+    /// `on_virtual_key_from_host` callback with the GUI-thread
+    /// `on_idle` callback. See [`KeyInjectState`].
+    pub(crate) key_inject: Arc<KeyInjectState>,
 }
 
 impl Editor for ViziaEditor {
@@ -108,6 +164,7 @@ impl Editor for ViziaEditor {
         .user_scale_factor(user_scale_factor)
         .on_idle({
             let emit_parameters_changed_event = self.emit_parameters_changed_event.clone();
+            let key_inject = self.key_inject.clone();
             move |cx| {
                 // Drain effects queued in `SYNC_RUNTIME` by off-UI-thread signal writes (our
                 // `ParamRegistry::flush_all()` runs on nih-plug's parameter-change callback,
@@ -133,6 +190,51 @@ impl Editor for ViziaEditor {
                         Event::new(RawParamEvent::ParametersChanged)
                             .propagate(Propagation::Subtree),
                     );
+                }
+
+                // Keep `text_focused` in sync so the host-thread
+                // `on_virtual_key_from_host` callback can decide
+                // synchronously whether to claim a key. The element
+                // name `"textbox"` is set by
+                // `vizia::views::Textbox::element()`.
+                key_inject.text_focused.store(
+                    cx.focused_element() == Some("textbox"),
+                    Ordering::Release,
+                );
+
+                // Drain any keys queued by `on_virtual_key_from_host`
+                // and dispatch them to the focused view. Buffered
+                // inside a short-lived lock to keep the critical
+                // section bounded.
+                //
+                // `on_virtual_key_from_host` has already classified
+                // each item on the host thread using the VST3
+                // `key_code`, so the drain just mechanically
+                // dispatches each variant: chars via
+                // `TextEvent::InsertText`, control keys via
+                // `WindowEvent::KeyDown` so the focused view's own
+                // key handler (e.g. textbox's `KeyDown` match arm)
+                // runs.
+                let drained: Vec<KeyInject> = {
+                    let mut q = key_inject
+                        .pending
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner());
+                    q.drain(..).collect()
+                };
+                if !drained.is_empty() {
+                    let mut ec = EventContext::new(cx);
+                    let target = ec.focused();
+                    for entry in drained {
+                        match entry {
+                            KeyInject::Char(c) => {
+                                ec.emit_to(target, TextEvent::InsertText(c.to_string()));
+                            }
+                            KeyInject::ControlKey(code, key) => {
+                                ec.emit_to(target, WindowEvent::KeyDown(code, Some(key)));
+                            }
+                        }
+                    }
                 }
             }
         });
@@ -189,6 +291,125 @@ impl Editor for ViziaEditor {
         self.param_registry.flush_all();
         self.emit_parameters_changed_event
             .store(true, Ordering::Relaxed);
+    }
+
+    fn on_virtual_key_from_host(
+        &self,
+        key_code: VirtualKeyCode,
+        is_down: bool,
+        modifiers: Modifiers,
+    ) -> bool {
+        // Called from the host's UI thread (e.g. REAPER dispatching
+        // `IPlugView::onKeyDown` / `onKeyUp`). Claim the key only when
+        // a textbox is currently focused; otherwise the host's
+        // accelerator (e.g. space -> transport) should run normally.
+        if !self.key_inject.text_focused.load(Ordering::Acquire) {
+            return false;
+        }
+
+        // Modifier-held combinations (Cmd+A, Cmd+Left, Shift+Arrow,
+        // Option+Backspace, etc.) are claimed by the host or handled by
+        // AppKit's `keyDown:` + `doCommandBySelector:` path where
+        // vizia's textbox reads modifier state for line/word movement.
+        // Dispatching through our injection queue here would double-fire
+        // and lose modifier context. Return `false` so the host keeps
+        // the key and AppKit's normal path runs.
+        if !modifiers.is_empty() {
+            return false;
+        }
+
+        // Classify the virtual key. The host hands us virtual keys that
+        // split into two groups vizia consumes differently:
+        //
+        // - Keys that represent a printable character (Space, numpad
+        //   digits/operators, `=`) go in as `TextEvent::InsertText`.
+        // - Named control keys (Backspace, Enter, arrows, F-keys,
+        //   etc.) go in as `WindowEvent::KeyDown(code, Some(key))` so
+        //   the focused view's own key handler (textbox's `KeyDown`
+        //   match arm for Backspace / Enter / arrows) runs.
+        //
+        // Keys we don't enumerate here (media / volume keys, Select,
+        // Print, modifier-only presses, Super) fall through to
+        // `return false` so the host's own binding runs.
+        let inject = match key_code {
+            VirtualKeyCode::Space => Some(KeyInject::Char(' ')),
+            VirtualKeyCode::Numpad0 => Some(KeyInject::Char('0')),
+            VirtualKeyCode::Numpad1 => Some(KeyInject::Char('1')),
+            VirtualKeyCode::Numpad2 => Some(KeyInject::Char('2')),
+            VirtualKeyCode::Numpad3 => Some(KeyInject::Char('3')),
+            VirtualKeyCode::Numpad4 => Some(KeyInject::Char('4')),
+            VirtualKeyCode::Numpad5 => Some(KeyInject::Char('5')),
+            VirtualKeyCode::Numpad6 => Some(KeyInject::Char('6')),
+            VirtualKeyCode::Numpad7 => Some(KeyInject::Char('7')),
+            VirtualKeyCode::Numpad8 => Some(KeyInject::Char('8')),
+            VirtualKeyCode::Numpad9 => Some(KeyInject::Char('9')),
+            VirtualKeyCode::NumpadMultiply => Some(KeyInject::Char('*')),
+            VirtualKeyCode::NumpadAdd => Some(KeyInject::Char('+')),
+            VirtualKeyCode::NumpadSeparator => Some(KeyInject::Char(',')),
+            VirtualKeyCode::NumpadSubtract => Some(KeyInject::Char('-')),
+            VirtualKeyCode::NumpadDecimal => Some(KeyInject::Char('.')),
+            VirtualKeyCode::NumpadDivide => Some(KeyInject::Char('/')),
+            VirtualKeyCode::Equals => Some(KeyInject::Char('=')),
+
+            VirtualKeyCode::Backspace => {
+                Some(KeyInject::ControlKey(Code::Backspace, Key::Backspace))
+            }
+            VirtualKeyCode::Tab => Some(KeyInject::ControlKey(Code::Tab, Key::Tab)),
+            VirtualKeyCode::Return => Some(KeyInject::ControlKey(Code::Enter, Key::Enter)),
+            VirtualKeyCode::NumpadEnter => {
+                Some(KeyInject::ControlKey(Code::NumpadEnter, Key::Enter))
+            }
+            VirtualKeyCode::Pause => Some(KeyInject::ControlKey(Code::Pause, Key::Pause)),
+            VirtualKeyCode::Escape => Some(KeyInject::ControlKey(Code::Escape, Key::Escape)),
+            VirtualKeyCode::End => Some(KeyInject::ControlKey(Code::End, Key::End)),
+            VirtualKeyCode::Home => Some(KeyInject::ControlKey(Code::Home, Key::Home)),
+            VirtualKeyCode::ArrowLeft => {
+                Some(KeyInject::ControlKey(Code::ArrowLeft, Key::ArrowLeft))
+            }
+            VirtualKeyCode::ArrowUp => Some(KeyInject::ControlKey(Code::ArrowUp, Key::ArrowUp)),
+            VirtualKeyCode::ArrowRight => {
+                Some(KeyInject::ControlKey(Code::ArrowRight, Key::ArrowRight))
+            }
+            VirtualKeyCode::ArrowDown => {
+                Some(KeyInject::ControlKey(Code::ArrowDown, Key::ArrowDown))
+            }
+            VirtualKeyCode::PageUp => Some(KeyInject::ControlKey(Code::PageUp, Key::PageUp)),
+            VirtualKeyCode::PageDown => Some(KeyInject::ControlKey(Code::PageDown, Key::PageDown)),
+            VirtualKeyCode::Insert => Some(KeyInject::ControlKey(Code::Insert, Key::Insert)),
+            VirtualKeyCode::Delete => Some(KeyInject::ControlKey(Code::Delete, Key::Delete)),
+            VirtualKeyCode::F1 => Some(KeyInject::ControlKey(Code::F1, Key::F1)),
+            VirtualKeyCode::F2 => Some(KeyInject::ControlKey(Code::F2, Key::F2)),
+            VirtualKeyCode::F3 => Some(KeyInject::ControlKey(Code::F3, Key::F3)),
+            VirtualKeyCode::F4 => Some(KeyInject::ControlKey(Code::F4, Key::F4)),
+            VirtualKeyCode::F5 => Some(KeyInject::ControlKey(Code::F5, Key::F5)),
+            VirtualKeyCode::F6 => Some(KeyInject::ControlKey(Code::F6, Key::F6)),
+            VirtualKeyCode::F7 => Some(KeyInject::ControlKey(Code::F7, Key::F7)),
+            VirtualKeyCode::F8 => Some(KeyInject::ControlKey(Code::F8, Key::F8)),
+            VirtualKeyCode::F9 => Some(KeyInject::ControlKey(Code::F9, Key::F9)),
+            VirtualKeyCode::F10 => Some(KeyInject::ControlKey(Code::F10, Key::F10)),
+            VirtualKeyCode::F11 => Some(KeyInject::ControlKey(Code::F11, Key::F11)),
+            VirtualKeyCode::F12 => Some(KeyInject::ControlKey(Code::F12, Key::F12)),
+
+            _ => None,
+        };
+
+        let Some(entry) = inject else {
+            return false;
+        };
+
+        // Vizia's text-input model is press-driven: TextEvent::InsertText
+        // and the textbox's KeyDown handlers run on the press only. Push
+        // the queued event on key-down; on key-up, just claim the event
+        // so the host doesn't pick the release up as a separate
+        // accelerator (BillyDM's reasoning on nih-plug#9).
+        if is_down {
+            self.key_inject
+                .pending
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push_back(entry);
+        }
+        true
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@ use nih_plug::params::persist::PersistentField;
 use nih_plug::prelude::{Editor, GuiContext};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use vizia::prelude::*;
 
 // Re-export for convenience

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ where
 
         emit_parameters_changed_event: Arc::new(AtomicBool::new(false)),
         param_registry: ParamRegistry::new(),
+        key_inject: editor::KeyInjectState::new(),
     }))
 }
 


### PR DESCRIPTION
## What

Implements `Editor::on_virtual_key_from_host` for the vizia-baseview backend. The impl tracks which vizia textbox has focus and, when the host delivers a virtual-key event, classifies and queues the key for dispatch on the next idle tick.

## Why I'm proposing this

VST3 hosts (REAPER, Ableton Live) bind Space, Backspace, arrows, Cmd+S etc. to their own accelerators, so those keys never reach the plug-in's NSView via the normal AppKit responder chain; a focused textbox in a vizia-plug plug-in misses them.

BillyDM/nih-plug recently added `Editor::on_virtual_key_from_host` ([BillyDM/nih-plug commit b59ce19b](https://codeberg.org/BillyDM/nih-plug/commit/b59ce19b), originally [Codeberg PR #9](https://codeberg.org/BillyDM/nih-plug/pulls/9), since merged) as the upstream forwarding hook: VST3 `IPlugView::onKeyDown` calls into the editor, which decides whether to consume the key or let the host's accelerator fire. This PR is the vizia-plug-side impl. I'd like to land it so vizia-plug plug-ins can have working keyboard input under VST3.

## How

- Printable virtual keys (Space, Numpad0..9, Numpad operators, Equals) are dispatched as `TextEvent::InsertText`.
- Named control keys (Backspace, Return, NumpadEnter, Escape, Home, End, arrows, PageUp/Down, Insert, Delete, F1..F12) go out as `WindowEvent::KeyDown` so the focused view's own key handling runs.
- Modifier-held combinations and keys we don't classify return `false` so the host's accelerator fires normally.
- Vizia's text-input model is press-driven; on key-up the impl returns `true` (claiming the event so the host doesn't pick up the release as a separate accelerator) but queues nothing.

Focus state is tracked via `cx.focused_element()` on every idle tick. The host-thread callback reads an `AtomicBool` to decide whether the focused view is a textbox.

## Vizia pin bump

The impl uses `Context::focused_element()`, added in vizia/vizia#672 (merged 2026-04-28). This PR bumps the `vizia` / `vizia_reactive` pin from `12ff2584` to `23e34039` (current vizia/main tip). The bump commit also picks up rustfmt drift between the two revs on the two files this PR touches.

## Tested

VST3 plug-in in REAPER on macOS: typing into a vizia textbox produces visible characters; Space, Backspace, arrows, Cmd+arrows reach the editor; and the host's accelerator no longer steals the key when a textbox is focused.

----

Fixes #7