### PR TITLE
chore: bump vizia pin to current main (3d04965d)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 nih_plug = { git = "https://github.com/BillyDM/nih-plug.git" }
-vizia = { git = "https://github.com/vizia/vizia", rev = "23e34039", default-features = false, features = ["baseview", "clipboard", "x11"] }
+vizia = { git = "https://github.com/vizia/vizia", rev = "3d04965d", default-features = false, features = ["baseview", "clipboard", "x11"] }
 # vizia = { path = "../vizia", default_features = false, features = ["baseview", "clipboard", "x11"] }
 
 # Direct dependency on `vizia_reactive` so the editor can call
@@ -26,7 +26,7 @@ vizia = { git = "https://github.com/vizia/vizia", rev = "23e34039", default-feat
 # AND `vizia_baseview`'s `on_frame_update` calls `Runtime::drain_pending_work()`
 # itself (matching what `vizia_winit` already does). Tracked in the companion
 # vizia PR — see CHANGELOG / PR description for the link.
-vizia_reactive = { git = "https://github.com/vizia/vizia", rev = "23e34039", default-features = false }
+vizia_reactive = { git = "https://github.com/vizia/vizia", rev = "3d04965d", default-features = false }
 
 crossbeam = "0.8"
 # Used by `ParamRegistry` for its signal map — flushing happens from the host /


### PR DESCRIPTION
Follow-up to #17. Bumps the `vizia` / `vizia_reactive` pin from `23e34039` (the vizia#672 merge commit set when #17 landed) to `3d04965d` (current vizia/main tip). Picks up two follow-up vizia merges:

- [vizia/vizia#674](https://github.com/vizia/vizia/pull/674) (`59158cfd`) — `vizia_baseview` Cmd+Q parented fix. `requests_exit` no longer treats Cmd+Q as an exit when the application is parented in a host. Resolves a Bitwig-on-macOS case where Cmd+Q tore down a plug-in's GL surface mid-session while the user was just trying to quit the DAW.
- [vizia/vizia#676](https://github.com/vizia/vizia/pull/676) (`3d04965d`) — bump vizia's baseview rev. Pulls in RustAudio/baseview#228 (macOS first-click `hitTest:` fix) and RustAudio/baseview#233 (cargo-clippy `cfg` lint workaround) on top of the existing keyboard-types 0.7 carry.

No vizia-plug-side code changes needed; both upstream merges are behavioural fixes inside `vizia` / `vizia_baseview` that vizia-plug already depends on. `cargo check` clean against the new pin.