### PR TITLE
Bump vizia rev and drop direct vizia_reactive dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,19 +14,8 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 nih_plug = { git = "https://github.com/BillyDM/nih-plug.git" }
-vizia = { git = "https://github.com/vizia/vizia", rev = "3d04965d8f1eb555b04dd60ef3a76c06bfd0603b", default-features = false, features = ["baseview", "clipboard", "x11"] }
+vizia = { git = "https://github.com/vizia/vizia", rev = "632527b7", default-features = false, features = ["baseview", "clipboard", "x11"] }
 # vizia = { path = "../vizia", default_features = false, features = ["baseview", "clipboard", "x11"] }
-
-# Direct dependency on `vizia_reactive` so the editor can call
-# `Runtime::drain_pending_work()` as a belt-and-suspenders against
-# `vizia_baseview`'s missing sync-runtime integration. Same rev as the `vizia`
-# umbrella above — resolves to the same crate in the dep graph.
-#
-# TODO: drop this dep once vizia re-exports `Runtime` from `vizia::prelude`
-# AND `vizia_baseview`'s `on_frame_update` calls `Runtime::drain_pending_work()`
-# itself (matching what `vizia_winit` already does). Tracked in the companion
-# vizia PR — see CHANGELOG / PR description for the link.
-vizia_reactive = { git = "https://github.com/vizia/vizia", rev = "23e34039", default-features = false }
 
 crossbeam = "0.8"
 # Used by `ParamRegistry` for its signal map — flushing happens from the host /

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -9,8 +9,6 @@ use std::sync::{Arc, Mutex};
 use vizia::prelude::*;
 use vizia::views::TextEvent;
 
-use vizia_reactive::Runtime;
-
 use crate::widgets::RawParamEvent;
 use crate::widgets::param_registry::ParamRegistry;
 use crate::{ViziaState, ViziaTheming, widgets};
@@ -165,22 +163,6 @@ impl Editor for ViziaEditor {
             let emit_parameters_changed_event = self.emit_parameters_changed_event.clone();
             let key_inject = self.key_inject.clone();
             move |cx| {
-                // Drain effects queued in `SYNC_RUNTIME` by off-UI-thread signal writes (our
-                // `ParamRegistry::flush_all()` runs on nih-plug's parameter-change callback,
-                // which is typically the host / audio thread). This ensures `Binding::new`
-                // subscribers get their rebuild-on-change notifications processed.
-                //
-                // Belt-and-suspenders: `vizia_baseview` should ideally call
-                // `Runtime::drain_pending_work()` from its own `on_frame_update` (matching
-                // what `vizia_winit` already does), in which case this call here becomes a
-                // redundant no-op. Until that lands upstream, this guarantees that
-                // vizia-plug-backed plugins see reactive updates with at most one event-loop
-                // tick of latency.
-                //
-                // TODO: remove once `vizia_baseview` integrates the sync runtime itself.
-                // Tracked by the companion vizia PR — see the vizia-plug PR description.
-                Runtime::drain_pending_work();
-
                 if emit_parameters_changed_event
                     .compare_exchange(true, false, Ordering::AcqRel, Ordering::Relaxed)
                     .is_ok()


### PR DESCRIPTION
Two changes on top of #18:

1. Drop the direct `vizia_reactive` dep + the `Runtime::drain_pending_work()` belt-and-suspenders call in `editor.rs::on_idle` + the matching import. Both TODO conditions documented above the dep landed upstream: `vizia_baseview` drains the sync runtime itself in `application.rs` (post-#663 chain), and `Runtime` is re-exported from `vizia::prelude`.

2. Bump the vizia rev from `3d04965d` to `632527b7` to pick up vizia#665 (focus auto-invalidate), which merged earlier today.

E2E-tested with a vizia-plug-backed plugin in Ableton + REAPER on macOS: knob drags, modal open/close, voice / color-region binding rebuilds all work without the in-plugin drain.