### PR TITLE
Add ViziaState::set_user_scale_factor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 nih_plug = { git = "https://github.com/BillyDM/nih-plug.git" }
-vizia = { git = "https://github.com/vizia/vizia", rev = "632527b7", default-features = false, features = ["baseview", "clipboard", "x11"] }
+vizia = { git = "https://github.com/vizia/vizia", rev = "e91b36f2", default-features = false, features = ["baseview", "clipboard", "x11"] }
 # vizia = { path = "../vizia", default_features = false, features = ["baseview", "clipboard", "x11"] }
 
 crossbeam = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,21 @@ impl ViziaState {
         self.scale_factor.load()
     }
 
+    /// Set the non-DPI related uniform scaling factor the GUI's size will be multiplied with.
+    ///
+    /// `Editor::size()` reads this via [`Self::scaled_logical_size`], so updating it before
+    /// calling [`nih_plug::context::gui::GuiContext::request_resize`] makes the host see the
+    /// freshly-zoomed dimensions and resize its parent window to match.
+    ///
+    /// On its own, this only changes what the host is told. To make the embedded vizia window
+    /// actually re-lay-out at the new scale, emit
+    /// [`vizia::prelude::WindowEvent::SetUserScale`] from the same handler. The
+    /// `vizia_baseview` backend handles that event by resizing the embedded window, bumping
+    /// `style.dpi_factor`, and refreshing the render surface in lockstep.
+    pub fn set_user_scale_factor(&self, factor: f64) {
+        self.scale_factor.store(factor);
+    }
+
     /// Whether the GUI is currently visible.
     // Called `is_open()` instead of `open()` to avoid the ambiguity.
     pub fn is_open(&self) -> bool {


### PR DESCRIPTION
Adds `ViziaState::set_user_scale_factor(f64)` to mirror the existing `user_scale_factor()` getter. The getter's docstring already mentions `cx.user_scale_factor` as the way to change the value, but no such API exists in vizia or here, so the field has been read-only from outside the crate. `Editor::size()` reads `scaled_logical_size()` which multiplies by this field, so updating it before calling `GuiContext::request_resize` makes the host re-query the editor's size and resize its parent window to match. Pairs with vizia#701 (`WindowEvent::SetUserScale`); rev bump included so the embedded `vizia_baseview` window can react to the same change and reflow the layout at the new scale. Together these land the user-driven scaling half of #6; host-driven resize still needs nih-plug `Editor` additions which are upstream-TODO there.