### PR TITLE
change/fix: nih-plug -> nice-plug :o

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = ["xtask", "examples/gain_gui"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-nih_plug = { git = "https://github.com/BillyDM/nih-plug.git" }
+nih_plug = { package = "nice-plug", git = "https://codeberg.org/BillyDM/nice-plug.git" }
 vizia = { git = "https://github.com/vizia/vizia", rev = "e91b36f2", default-features = false, features = ["baseview", "clipboard", "x11"] }
 # vizia = { path = "../vizia", default_features = false, features = ["baseview", "clipboard", "x11"] }
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Vizia Plug
 
-A replacement for `nih-plug-vizia` which updates it to the latest version of `vizia`.
+A replacement for the old `nih-plug-vizia` which updates it to the latest version of `vizia`.
 
-This crate allows for the use of the Vizia GUI library to be used with the nice-plug (formerly NIH-plug) plugin framework.
+This crate allows for the use of the Vizia GUI library to be used with the [nice-plug](https://codeberg.org/BillyDM/nice-plug.git) (formerly NIH-plug) plugin framework.
 
 ## Building Examples
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A replacement for `nih-plug-vizia` which updates it to the latest version of `vizia`.
 
-This crate allows for the use of the Vizia GUI library to be used with the nih-plug plugin framework.
+This crate allows for the use of the Vizia GUI library to be used with the nice-plug (formerly NIH-plug) plugin framework.
 
 ## Building Examples
 

--- a/examples/gain_gui/Cargo.toml
+++ b/examples/gain_gui/Cargo.toml
@@ -11,7 +11,7 @@ description = "A simple gain plugin with an vizia GUI"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-nih_plug = { git = "https://github.com/robbert-vdh/nih-plug", features = ["standalone"] }
+nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git", features = ["standalone"] }
 vizia_plug = { path = "../../" }
 
 atomic_float = "0.1"

--- a/examples/gain_gui/Cargo.toml
+++ b/examples/gain_gui/Cargo.toml
@@ -11,7 +11,7 @@ description = "A simple gain plugin with an vizia GUI"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-nih_plug = { git = "https://github.com/robbert-vdh/nih-plug.git", features = ["standalone"] }
+nih_plug = { git = "https://github.com/robbert-vdh/nih-plug", features = ["standalone"] }
 vizia_plug = { path = "../../" }
 
 atomic_float = "0.1"

--- a/examples/gain_gui/Cargo.toml
+++ b/examples/gain_gui/Cargo.toml
@@ -11,7 +11,7 @@ description = "A simple gain plugin with an vizia GUI"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-nih_plug = { git = "https://github.com/robbert-vdh/nih-plug", features = ["standalone"] }
+nih_plug = { package = "nice-plug", git = "https://codeberg.org/BillyDM/nice-plug", features = ["standalone"] }
 vizia_plug = { path = "../../" }
 
 atomic_float = "0.1"

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -116,7 +116,7 @@ impl Editor for ViziaEditor {
             // The default font is now controlled through stylesheets — `theme.css` below
             // can set `* { font-family: ...; }` if a specific font is required.
             if let Err(err) = cx.add_stylesheet(include_style!("src/assets/theme.css")) {
-                nih_error!("Failed to load stylesheet: {err:?}");
+                nice_error!("Failed to load stylesheet: {err:?}");
                 panic!();
             }
 

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -30,7 +30,7 @@ pub use peak_meter::PeakMeter;
 /// for you when using [`create_vizia_editor()`][super::create_vizia_editor()].
 pub fn register_theme(cx: &mut Context) {
     if let Err(err) = cx.add_stylesheet(include_style!("src/assets/widgets.css")) {
-        nih_error!("Failed to load stylesheet: {err:?}")
+        nice_error!("Failed to load stylesheet: {err:?}")
     }
 }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nih_plug_xtask = { git = "https://github.com/BillyDM/nih-plug.git" }
+nih_plug_xtask = { package = "nice-plug-xtask", git = "https://codeberg.org/BillyDM/nice-plug.git" }


### PR DESCRIPTION
BillyDM's nih-plug fork is now called nice-plug, the repo name was changed as well. The old link still works as it redirects to the correct page but yk it's not correct anymore, and idk if it works with cargo, and even if it does I don't know how long it'll stay working. It's good to have correct. So behold... this pull request!

I took the liberty of also adding some stuff to the README and using the fork as a dep in the gain_gui example :p

I did the `dep = { package = "dep_name" }` thing, which means there was basically no refactoring in the actual code, Idk if that's competent, sorry if it's not. I was more focused on just getting the dep right. If anything the PR can be updated with refactors

o/