### PR TITLE
Switch nih_plug references to nice-plug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = ["xtask", "examples/gain_gui"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-nih_plug = { package = "nice-plug", git = "https://codeberg.org/BillyDM/nice-plug.git" }
+nice-plug = { git = "https://codeberg.org/BillyDM/nice-plug.git" }
 vizia = { git = "https://github.com/vizia/vizia", rev = "e91b36f2", default-features = false, features = ["baseview", "clipboard", "x11"] }
 # vizia = { path = "../vizia", default_features = false, features = ["baseview", "clipboard", "x11"] }
 

--- a/examples/gain_gui/Cargo.toml
+++ b/examples/gain_gui/Cargo.toml
@@ -11,7 +11,7 @@ description = "A simple gain plugin with an vizia GUI"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-nih_plug = { package = "nice-plug", git = "https://codeberg.org/BillyDM/nice-plug", features = ["standalone"] }
+nice-plug = { git = "https://codeberg.org/BillyDM/nice-plug", features = ["standalone"] }
 vizia_plug = { path = "../../" }
 
 atomic_float = "0.1"

--- a/examples/gain_gui/src/editor.rs
+++ b/examples/gain_gui/src/editor.rs
@@ -1,5 +1,5 @@
 use atomic_float::AtomicF32;
-use nih_plug::prelude::{util, Editor};
+use nice_plug::prelude::{util, Editor};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;

--- a/examples/gain_gui/src/lib.rs
+++ b/examples/gain_gui/src/lib.rs
@@ -1,5 +1,5 @@
 use atomic_float::AtomicF32;
-use nih_plug::prelude::*;
+use nice_plug::prelude::*;
 use vizia_plug::ViziaState;
 use std::sync::Arc;
 
@@ -175,5 +175,5 @@ impl Vst3Plugin for Gain {
         &[Vst3SubCategory::Fx, Vst3SubCategory::Tools];
 }
 
-nih_export_clap!(Gain);
-nih_export_vst3!(Gain);
+nice_export_clap!(Gain);
+nice_export_vst3!(Gain);

--- a/examples/gain_gui/src/main.rs
+++ b/examples/gain_gui/src/main.rs
@@ -1,7 +1,7 @@
-use nih_plug::prelude::*;
+use nice_plug::prelude::*;
 
 use gain_gui::Gain;
 
 fn main() {
-    nih_export_standalone::<Gain>();
+    nice_export_standalone::<Gain>();
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,8 +1,8 @@
 //! The [`Editor`] trait implementation for Vizia editors.
 
 use crossbeam::atomic::AtomicCell;
-use nih_plug::debug::*;
-use nih_plug::prelude::{Editor, GuiContext, Modifiers, ParentWindowHandle, VirtualKeyCode};
+use nice_plug::debug::*;
+use nice_plug::prelude::{Editor, GuiContext, Modifiers, ParentWindowHandle, VirtualKeyCode};
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -84,7 +84,7 @@ pub(crate) struct ViziaEditor {
     /// Shared registry of `SyncSignal<f32>`s tracking each parameter's live value. Widgets
     /// subscribe via `cx.data::<ParamRegistry>()`; the editor calls `flush_all()` from the
     /// `parameter_value_changed` / `parameter_values_changed` hooks so the reactive graph picks
-    /// up value changes that nih-plug reports.
+    /// up value changes that nice-plug reports.
     pub(crate) param_registry: ParamRegistry,
 
     /// Shared state bridging the host-thread
@@ -378,7 +378,7 @@ impl Editor for ViziaEditor {
         // and the textbox's KeyDown handlers run on the press only. Push
         // the queued event on key-down; on key-up, just claim the event
         // so the host doesn't pick the release up as a separate
-        // accelerator (BillyDM's reasoning on nih-plug#9).
+        // accelerator (BillyDM's reasoning on nice-plug#9).
         if is_down {
             self.key_inject
                 .pending

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 //! [VIZIA](https://github.com/vizia/vizia) editor support for NIH plug.
 
-// See the comment in the main `nih_plug` crate
+// See the comment in the main `nice_plug` crate
 #![allow(clippy::type_complexity)]
 
 use crossbeam::atomic::AtomicCell;
-use nih_plug::params::persist::PersistentField;
-use nih_plug::prelude::{Editor, GuiContext};
+use nice_plug::params::persist::PersistentField;
+use nice_plug::prelude::{Editor, GuiContext};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -95,7 +95,7 @@ pub struct ViziaState {
     size_fn: Box<dyn Fn() -> (u32, u32) + Send + Sync>,
     /// A scale factor that should be applied to `size` separate from from any system HiDPI scaling.
     /// This can be used to allow GUIs to be scaled uniformly.
-    #[serde(with = "nih_plug::params::persist::serialize_atomic_cell")]
+    #[serde(with = "nice_plug::params::persist::serialize_atomic_cell")]
     scale_factor: AtomicCell<f64>,
     /// Whether the editor's window is currently open.
     #[serde(skip)]
@@ -186,7 +186,7 @@ impl ViziaState {
     /// Set the non-DPI related uniform scaling factor the GUI's size will be multiplied with.
     ///
     /// `Editor::size()` reads this via [`Self::scaled_logical_size`], so updating it before
-    /// calling [`nih_plug::context::gui::GuiContext::request_resize`] makes the host see the
+    /// calling [`nice_plug::context::gui::GuiContext::request_resize`] makes the host see the
     /// freshly-zoomed dimensions and resize its parent window to match.
     ///
     /// On its own, this only changes what the host is told. To make the embedded vizia window

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -6,8 +6,8 @@
 //! to copy the widgets and modify them to your personal taste.
 
 use crossbeam::atomic::AtomicCell;
-use nih_plug::debug::*;
-use nih_plug::prelude::{GuiContext, Param, ParamPtr};
+use nice_plug::debug::*;
+use nice_plug::prelude::{GuiContext, Param, ParamPtr};
 use std::sync::Arc;
 use vizia::prelude::*;
 
@@ -161,7 +161,7 @@ impl Model for WindowModel {
         //         let logical_size = (cx.window_size().width, cx.window_size().height);
         //         // `self.vizia_state.inner_logical_size()` should match `logical_size`. Since it's
         //         // computed we need to store the last logical size on this object.
-        //         nih_debug_assert_eq!(
+        //         nice_debug_assert_eq!(
         //             logical_size,
         //             self.vizia_state.inner_logical_size(),
         //             "The window size set on the vizia context does not match the size returned by \

--- a/src/widgets/generic_ui.rs
+++ b/src/widgets/generic_ui.rs
@@ -1,6 +1,6 @@
 //! Generic UIs for NIH-plug using VIZIA.
 
-use nih_plug::prelude::{ParamFlags, ParamPtr, Params};
+use nice_plug::prelude::{ParamFlags, ParamPtr, Params};
 use vizia::prelude::*;
 
 use super::{ParamSlider, ParamSliderExt, ParamSliderStyle};

--- a/src/widgets/param_base.rs
+++ b/src/widgets/param_base.rs
@@ -1,6 +1,6 @@
 //! A base widget for creating other widgets that integrate with NIH-plug's [`Param`] types.
 
-use nih_plug::prelude::*;
+use nice_plug::prelude::*;
 use vizia::prelude::*;
 
 use super::param_registry::{ParamAxis, ParamRegistry};

--- a/src/widgets/param_button.rs
+++ b/src/widgets/param_button.rs
@@ -1,12 +1,12 @@
 //! A toggleable button that integrates with NIH-plug's [`Param`] types.
 
-use nih_plug::prelude::Param;
+use nice_plug::prelude::Param;
 use vizia::prelude::*;
 
 use super::param_base::ParamWidgetBase;
 
 /// A toggleable button that integrates with NIH-plug's [`Param`] types. Only makes sense with
-/// [`BoolParam`][nih_plug::prelude::BoolParam]s. Clicking the button toggles between the
+/// [`BoolParam`][nice_plug::prelude::BoolParam]s. Clicking the button toggles between the
 /// parameter's minimum and maximum value. The `:checked` pseudoclass indicates whether the
 /// button is currently pressed.
 pub struct ParamButton {

--- a/src/widgets/param_registry.rs
+++ b/src/widgets/param_registry.rs
@@ -1,7 +1,7 @@
-//! Bridge between nih-plug's pull-based [`Param`] model and vizia's push-based
+//! Bridge between nice-plug's pull-based [`Param`] model and vizia's push-based
 //! [`SyncSignal`] reactive graph.
 //!
-//! nih-plug exposes parameters through [`ParamPtr`] — stable opaque handles whose current
+//! nice-plug exposes parameters through [`ParamPtr`] — stable opaque handles whose current
 //! values are read on demand via unsafe accessors. vizia's new signal-based binding system
 //! (vizia#619) requires observable values to be wrapped in [`SyncSignal`] so the reactive
 //! graph can track dependencies and push updates to subscribers.
@@ -13,9 +13,9 @@
 //! access and reuses them on subsequent accesses.
 //!
 //! The editor side is responsible for flushing current values from [`ParamPtr`]s into the
-//! registry's signals whenever nih-plug reports a parameter change (via
-//! [`Editor::parameter_value_changed`](nih_plug::prelude::Editor::parameter_value_changed) /
-//! [`Editor::parameter_values_changed`](nih_plug::prelude::Editor::parameter_values_changed)).
+//! registry's signals whenever nice-plug reports a parameter change (via
+//! [`Editor::parameter_value_changed`](nice_plug::prelude::Editor::parameter_value_changed) /
+//! [`Editor::parameter_values_changed`](nice_plug::prelude::Editor::parameter_values_changed)).
 //! See [`ParamRegistry::flush_all`].
 //!
 //! The type is cheaply `Clone` (it's an `Arc` internally), so the editor can keep its own
@@ -24,11 +24,11 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use nih_plug::prelude::ParamPtr;
+use nice_plug::prelude::ParamPtr;
 use parking_lot::Mutex;
 use vizia::prelude::*;
 
-/// Which value of a parameter a signal tracks. nih-plug distinguishes between the raw
+/// Which value of a parameter a signal tracks. nice-plug distinguishes between the raw
 /// user/host-set value (*unmodulated*) and the value after any monophonic modulation has been
 /// applied (*modulated*). Most widgets want modulated — it's what the user sees driving the
 /// audio — but some (e.g. a slider that visualises both) want both.
@@ -52,7 +52,7 @@ struct ParamRegistryInner {
     /// Lazily populated map of `(ParamPtr, axis)` → signal.
     ///
     /// Locked briefly by widgets on construction (UI thread) and by the editor on every
-    /// parameter-change callback ([`flush_all`](ParamRegistry::flush_all), which nih-plug
+    /// parameter-change callback ([`flush_all`](ParamRegistry::flush_all), which nice-plug
     /// calls on the host / audio thread). Using `parking_lot::Mutex` rather than
     /// `std::sync::Mutex` keeps the audio-thread side light — no poisoning checks, no
     /// priority-inversion hazard if the UI thread is holding the lock during widget build.
@@ -99,7 +99,7 @@ impl ParamRegistry {
 
     /// Re-read every registered parameter via unsafe `ParamPtr` and write the current value
     /// into its signal. Intended to be called from the editor's
-    /// [`parameter_values_changed`](nih_plug::prelude::Editor::parameter_values_changed) hook
+    /// [`parameter_values_changed`](nice_plug::prelude::Editor::parameter_values_changed) hook
     /// (which reports "something moved but we don't know what") so every widget catches up
     /// in one sweep.
     pub fn flush_all(&self) {
@@ -120,8 +120,8 @@ impl ParamRegistry {
     /// Re-read a single parameter via unsafe `ParamPtr` and write its current value into each
     /// of its registered axis signals (modulated + unmodulated). Intended to be called from
     /// the editor's
-    /// [`parameter_value_changed`](nih_plug::prelude::Editor::parameter_value_changed) /
-    /// [`parameter_modulation_changed`](nih_plug::prelude::Editor::parameter_modulation_changed)
+    /// [`parameter_value_changed`](nice_plug::prelude::Editor::parameter_value_changed) /
+    /// [`parameter_modulation_changed`](nice_plug::prelude::Editor::parameter_modulation_changed)
     /// hooks — both of which report the specific parameter that moved — so a single-parameter
     /// change doesn't iterate every signal in the registry.
     ///

--- a/src/widgets/param_slider.rs
+++ b/src/widgets/param_slider.rs
@@ -1,6 +1,6 @@
 //! A slider that integrates with NIH-plug's [`Param`] types.
 
-use nih_plug::prelude::{Param, ParamPtr};
+use nice_plug::prelude::{Param, ParamPtr};
 use vizia::prelude::*;
 
 use super::param_base::ParamWidgetBase;

--- a/src/widgets/peak_meter.rs
+++ b/src/widgets/peak_meter.rs
@@ -1,6 +1,6 @@
 //! A super simple peak meter widget.
 
-use nih_plug::prelude::util;
+use nice_plug::prelude::util;
 use std::cell::Cell;
 use std::time::Duration;
 use std::time::Instant;

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-nih_plug_xtask = { package = "nice-plug-xtask", git = "https://codeberg.org/BillyDM/nice-plug.git" }
+nice_plug_xtask = { package = "nice-plug-xtask", git = "https://codeberg.org/BillyDM/nice-plug.git" }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,3 +1,3 @@
-fn main() -> nih_plug_xtask::Result<()> {
-    nih_plug_xtask::main()
+fn main() -> nice_plug_xtask::Result<()> {
+    nice_plug_xtask::main()
 }


### PR DESCRIPTION
Migrate code and build files to use the renamed crate (nice-plug). Updated Cargo.toml entries and example/xtask manifests, replaced imports and paths from nih_plug to nice_plug/nice-plug across source files, and adjusted macro/function names (e.g. nih_export_* -> nice_export_*, nih_export_standalone -> nice_export_standalone). Also updated debug/assert macro usage, serde serialize path, and inline comments to reflect the new crate name. This completes the crate rename migration so the project builds against the new package name.