### PR TITLE
Replace nice-plug with nice-plug-core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 authors = ["George Atkinson <geom3trik@vizia.dev>"]
 license = "MIT"
-description = "An adapter to use VIZIA GUIs with NIH-plug"
+description = "An adapter to use VIZIA GUIs with nice-plug"
 
 [workspace]
 members = ["xtask", "examples/gain_gui"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = ["xtask", "examples/gain_gui"]
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-nice-plug = "0.1.8"
+nice-plug-core = "0.1.4"
 vizia = { git = "https://github.com/vizia/vizia", rev = "bbf98e643333d2533983f5866296036c34284018", default-features = false, features = ["baseview", "clipboard", "x11"] }
 vizia_reactive = { git = "https://github.com/vizia/vizia", rev = "bbf98e643333d2533983f5866296036c34284018" }
 # vizia = { path = "../vizia", default_features = false, features = ["baseview", "clipboard", "x11"] }

--- a/examples/gain_gui/Cargo.toml
+++ b/examples/gain_gui/Cargo.toml
@@ -13,5 +13,3 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 nice-plug = { version = "0.1.8", features = ["standalone"] }
 vizia_plug = { path = "../../" }
-
-atomic_float = "0.1"

--- a/examples/gain_gui/src/editor.rs
+++ b/examples/gain_gui/src/editor.rs
@@ -1,5 +1,5 @@
-use atomic_float::AtomicF32;
 use nice_plug::prelude::{util, Editor};
+use nice_plug::util::AtomicF32;
 use std::sync::Arc;
 use std::time::Duration;
 use vizia_plug::vizia::prelude::*;

--- a/examples/gain_gui/src/lib.rs
+++ b/examples/gain_gui/src/lib.rs
@@ -1,7 +1,7 @@
-use atomic_float::AtomicF32;
 use nice_plug::prelude::*;
-use vizia_plug::ViziaState;
+use nice_plug::util::AtomicF32;
 use std::sync::Arc;
+use vizia_plug::ViziaState;
 
 mod editor;
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,8 +1,9 @@
 //! The [`Editor`] trait implementation for Vizia editors.
 
 use crossbeam::atomic::AtomicCell;
-use nice_plug::debug::*;
-use nice_plug::prelude::{Editor, GuiContext, Modifiers, ParentWindowHandle, VirtualKeyCode};
+use nice_plug_core::context::gui::GuiContext;
+use nice_plug_core::debug::*;
+use nice_plug_core::editor::{Editor, Modifiers, ParentWindowHandle, VirtualKeyCode};
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -143,8 +144,7 @@ impl Editor for ViziaEditor {
 
             // And we'll link `WindowEvent::ResizeWindow` and `WindowEvent::SetScale` events to our
             // `ViziaState`. We'll notify the host when any of these change.
-            let current_inner_window_size =
-                EventContext::new(cx).cache.get_bounds(Entity::root());
+            let current_inner_window_size = EventContext::new(cx).cache.get_bounds(Entity::root());
             widgets::WindowModel {
                 context: context.clone(),
                 vizia_state: vizia_state.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,9 @@
 #![allow(clippy::type_complexity)]
 
 use crossbeam::atomic::AtomicCell;
-use nice_plug::params::persist::PersistentField;
-use nice_plug::prelude::{Editor, GuiContext};
+use nice_plug_core::context::gui::GuiContext;
+use nice_plug_core::editor::Editor;
+use nice_plug_core::params::persist::PersistentField;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -95,7 +96,7 @@ pub struct ViziaState {
     size_fn: Box<dyn Fn() -> (u32, u32) + Send + Sync>,
     /// A scale factor that should be applied to `size` separate from from any system HiDPI scaling.
     /// This can be used to allow GUIs to be scaled uniformly.
-    #[serde(with = "nice_plug::params::persist::serialize_atomic_cell")]
+    #[serde(with = "nice_plug_core::params::persist::serialize_atomic_cell")]
     scale_factor: AtomicCell<f64>,
     /// Whether the editor's window is currently open.
     #[serde(skip)]

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -6,8 +6,10 @@
 //! to copy the widgets and modify them to your personal taste.
 
 use crossbeam::atomic::AtomicCell;
-use nice_plug::debug::*;
-use nice_plug::prelude::{GuiContext, Param, ParamPtr};
+use nice_plug_core::context::gui::GuiContext;
+use nice_plug_core::debug::*;
+use nice_plug_core::params::Param;
+use nice_plug_core::params::internals::ParamPtr;
 use std::sync::Arc;
 use vizia::prelude::*;
 

--- a/src/widgets/generic_ui.rs
+++ b/src/widgets/generic_ui.rs
@@ -1,6 +1,7 @@
 //! Generic UIs for NIH-plug using VIZIA.
 
-use nice_plug::prelude::{ParamFlags, ParamPtr, Params};
+use nice_plug_core::params::internals::ParamPtr;
+use nice_plug_core::params::{ParamFlags, Params};
 use vizia::prelude::*;
 
 use super::{ParamSlider, ParamSliderExt, ParamSliderStyle};

--- a/src/widgets/param_base.rs
+++ b/src/widgets/param_base.rs
@@ -1,10 +1,11 @@
 //! A base widget for creating other widgets that integrate with NIH-plug's [`Param`] types.
 
-use nice_plug::prelude::*;
+use nice_plug_core::params::internals::ParamPtr;
+use nice_plug_core::params::{Param, ParamFlags};
 use vizia::prelude::*;
 
-use super::param_registry::{ParamAxis, ParamRegistry};
 use super::RawParamEvent;
+use super::param_registry::{ParamAxis, ParamRegistry};
 
 /// A helper for creating parameter widgets. The general idea is that a parameter widget struct
 /// stores a [`ParamWidgetBase`] field, calls [`ParamWidgetBase::view`] in its build function,
@@ -111,7 +112,9 @@ impl ParamWidgetBase {
     /// }
     /// ```
     pub fn new<P: Param>(_cx: &Context, param: &P) -> Self {
-        Self { param_ptr: param.as_ptr() }
+        Self {
+            param_ptr: param.as_ptr(),
+        }
     }
 
     /// Create a view using the parameter's data. The `content` closure receives a
@@ -125,16 +128,16 @@ impl ParamWidgetBase {
         P: Param + 'static,
         F: FnOnce(&mut Context, ParamWidgetData<'a, P>) -> R,
     {
-        let param_data = ParamWidgetData { param, param_ptr: param.as_ptr() };
+        let param_data = ParamWidgetData {
+            param,
+            param_ptr: param.as_ptr(),
+        };
         content(cx, param_data)
     }
 
     /// Shorthand for [`view`](Self::view) that returns a builder closure suitable for
     /// [`View::build`](vizia::prelude::View::build).
-    pub fn build_view<'a, P, F, R>(
-        param: &'a P,
-        content: F,
-    ) -> impl FnOnce(&mut Context) -> R + 'a
+    pub fn build_view<'a, P, F, R>(param: &'a P, content: F) -> impl FnOnce(&mut Context) -> R + 'a
     where
         P: Param + 'static,
         F: FnOnce(&mut Context, ParamWidgetData<'a, P>) -> R + 'a,

--- a/src/widgets/param_button.rs
+++ b/src/widgets/param_button.rs
@@ -1,6 +1,6 @@
 //! A toggleable button that integrates with NIH-plug's [`Param`] types.
 
-use nice_plug::prelude::Param;
+use nice_plug_core::params::Param;
 use vizia::prelude::*;
 
 use super::param_base::ParamWidgetBase;

--- a/src/widgets/param_registry.rs
+++ b/src/widgets/param_registry.rs
@@ -24,7 +24,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use nice_plug::prelude::ParamPtr;
+use nice_plug_core::params::internals::ParamPtr;
 use parking_lot::Mutex;
 use vizia::prelude::*;
 

--- a/src/widgets/param_slider.rs
+++ b/src/widgets/param_slider.rs
@@ -1,6 +1,7 @@
 //! A slider that integrates with NIH-plug's [`Param`] types.
 
-use nice_plug::prelude::{Param, ParamPtr};
+use nice_plug_core::params::Param;
+use nice_plug_core::params::internals::ParamPtr;
 use vizia::prelude::*;
 
 use super::param_base::ParamWidgetBase;

--- a/src/widgets/peak_meter.rs
+++ b/src/widgets/peak_meter.rs
@@ -1,6 +1,6 @@
 //! A super simple peak meter widget.
 
-use nice_plug::prelude::util;
+use nice_plug_core::util;
 use std::cell::Cell;
 use std::sync::Arc;
 use std::time::Duration;
@@ -218,10 +218,7 @@ impl PeakMeterBar {
         let mut held = self.held_peak_dbfs.get();
         let held_at = self.last_held_at.get();
 
-        if current_level_dbfs >= held
-            || held_at.is_none()
-            || now > held_at.unwrap() + hold_time
-        {
+        if current_level_dbfs >= held || held_at.is_none() || now > held_at.unwrap() + hold_time {
             held = current_level_dbfs;
             self.held_peak_dbfs.set(held);
             self.last_held_at.set(Some(now));
@@ -282,8 +279,8 @@ impl View for PeakMeterBar {
         let bar_tick_coordinates = (bar_ticks_start_x..bar_ticks_end_x)
             .step_by(((TICK_WIDTH + TICK_GAP) * dpi_scale).round() as usize);
         for tick_x in bar_tick_coordinates {
-            let tick_fraction = (tick_x - bar_ticks_start_x) as f32
-                / (bar_ticks_end_x - bar_ticks_start_x) as f32;
+            let tick_fraction =
+                (tick_x - bar_ticks_start_x) as f32 / (bar_ticks_end_x - bar_ticks_start_x) as f32;
             let tick_db = (tick_fraction * (MAX_TICK - MIN_TICK)) + MIN_TICK;
             if tick_db > level_dbfs {
                 break;


### PR DESCRIPTION
Replaces the `nice-plug` dependency with `nice-plug-core` for the crate.  The goal of `nice-plug-core` is to stay semver compatible, so that gui adapters don't have to follow updates of `nice-plug`.

Notes:
- The change has no impact on the plugin itself (and the example) as this should still use `nice-plug`. All items from `nice-plug-core` are re-exported there.
- The `atomic-float` crate is also now obsolete in the plugin/example as `AtomicF32` is provided by the `nice_plug::util` module.